### PR TITLE
added allow_pickle=True to np.load() as required by recent numpy versions

### DIFF
--- a/tensornets/utils.py
+++ b/tensornets/utils.py
@@ -348,7 +348,7 @@ def pretrained_initializer(scope, values):
 
 
 def parse_weights(weights_path, move_rules=None):
-    data = np.load(weights_path, encoding='bytes')
+    data = np.load(weights_path, encoding='bytes', allow_pickle=True)
     values = data['values']
 
     if tf_later_than('1.3.0'):


### PR DESCRIPTION
Had this error using ResNet50v2:

> Traceback (most recent call last):
  File "D:\Eigene Dateien\Uni HH Master Inf\2. Semester\CV2\CV2-2019-Proj\experiments\resnet_tensornets.py", line 34, in <module>
    sess.run(model.pretrained())
  File "C:\Users\Oliver\AppData\Local\Programs\Python\Python37\lib\site-packages\tensornets\pretrained.py", line 99, in _direct
    return fun(scope, return_fn=pretrained_initializer)
  File "C:\Users\Oliver\AppData\Local\Programs\Python\Python37\lib\site-packages\tensornets\pretrained.py", line 223, in load_resnet50v2
    values = parse_weights(weights_path)
  File "C:\Users\Oliver\AppData\Local\Programs\Python\Python37\lib\site-packages\tensornets\utils.py", line 342, in parse_weights
    values = data['values']
  File "C:\Users\Oliver\AppData\Local\Programs\Python\Python37\lib\site-packages\numpy\lib\npyio.py", line 262, in __getitem__
    pickle_kwargs=self.pickle_kwargs)
  File "C:\Users\Oliver\AppData\Local\Programs\Python\Python37\lib\site-packages\numpy\lib\format.py", line 696, in read_array
    raise ValueError("Object arrays cannot be loaded when "
ValueError: Object arrays cannot be loaded when allow_pickle=False

And then I fixed it according to:

- https://stackoverflow.com/questions/55890813/how-to-fix-object-arrays-cannot-be-loaded-when-allow-pickle-false-for-imdb-loa
- https://github.com/tensorflow/tensorflow/commit/79a8d5cdad942b9853aa70b59441983b42a8aeb3#diff-b0a029ad68170f59173eb2f6660cd8e0
