### PR TITLE
Add TF 2 supports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,23 @@ matrix:
     - python: 3.6
       env: TEST_MODE=PEP8
     - python: 3.6
-      env: TF_VERSION1=1.1.0 TF_VERSION2=1.2.0
+      env: TF_VERSION1=1.4.0 TF_VERSION2=1.5.0
     - python: 3.6
-      env: TF_VERSION1=1.3.0 TF_VERSION2=1.4.0
+      env: TF_VERSION1=1.6.0 TF_VERSION2=1.7.0
     - python: 3.6
-      env: TF_VERSION1=1.5.0 TF_VERSION2=1.6.0
+      env: TF_VERSION1=1.8.0 TF_VERSION2=1.9.0
     - python: 3.6
-      env: TF_VERSION1=1.7.0 TF_VERSION2=1.8.0
+      env: TF_VERSION1=1.10.0 TF_VERSION2=1.11.0
     - python: 3.6
-      env: TF_VERSION1=1.9.0 TF_VERSION2=1.10.0
+      env: TF_VERSION1=1.12.0 TF_VERSION2=1.13.1
     - python: 3.6
-      env: TF_VERSION1=1.11.0 TF_VERSION2=1.12.0
+      env: TF_VERSION1=1.14.0 TF_VERSION2=1.15.0
     - python: 3.6
-      env: TF_VERSION1=1.13.1 TF_VERSION2=1.14.0
+      env: TF_VERSION1=2.0.0 TF_VERSION2=2.1.0
     - python: 2.7
-      env: TF_VERSION1=1.3.0 TF_VERSION2=1.8.0
+      env: TF_VERSION1=1.4.0 TF_VERSION2=1.15.0
     - python: 2.7
+      env: TF_VERSION1=2.0.0 TF_VERSION2=2.1.0
 notifications:
   email: false
 # Adapted from

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorNets
 
-High level network definitions with pre-trained weights in [TensorFlow](https://github.com/tensorflow/tensorflow) (tested with `>= 1.1.0`).
+High level network definitions with pre-trained weights in [TensorFlow](https://github.com/tensorflow/tensorflow) (tested with `2.1.0 >=` TF `>= 1.4.0`).
 
 ## Guiding principles
 
@@ -19,7 +19,9 @@ Each network (see [full list](#image-classification)) is not a custom class but 
 
 ```python
 import tensorflow as tf
+# import tensorflow.compat.v1 as tf  # for TF 2
 import tensornets as nets
+# tf.disable_v2_behavior()  # for TF 2
 
 inputs = tf.placeholder(tf.float32, [None, 224, 224, 3])
 model = nets.ResNet50(inputs)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
-pep8ignore=E226 E701 E111 E114
+pep8ignore=
+    *.py E226 E701 E111 E114
+    tensornets/contrib_framework/*.py ALL
+    tensornets/contrib_layers/*.py ALL
 pep8maxlinelength=119

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='tensornets',
       download_url='https://github.com/taehoonlee/tensornets/tarball/0.4.1',
       license='MIT',
       packages=['tensornets', 'tensornets.datasets',
+                'tensornets.contrib_framework', 'tensornets.contrib_layers',
                 'tensornets.references', ext],
       include_package_data=True,
       ext_modules=cythonize(ext_modules))

--- a/tensornets/capsulenets.py
+++ b/tensornets/capsulenets.py
@@ -52,8 +52,8 @@ def primary(x, filters, length, kernel_size, stride, scope=None):
 
 @var_scope('digit')
 def digit(x, filters, length, iters=3, scope=None):
-    filters0 = x.shape[1].value
-    length0 = x.shape[2].value
+    filters0 = int(x.shape[1]) if tf_later_than('2') else x.shape[1].value
+    length0 = int(x.shape[2]) if tf_later_than('2') else x.shape[2].value
 
     # fully-connected weights between capsules: [1152, 8, 10 * 16]
     w = tf.get_variable('weights', shape=(filters0, length0, filters * length),

--- a/tensornets/contrib_framework/__init__.py
+++ b/tensornets/contrib_framework/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""A module containing TensorFlow ops whose API may change in the future."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# TODO(ptucker): Add these to tf.contrib.variables?
+# pylint: disable=wildcard-import
+from .arg_scope import *
+#from .checkpoint_ops import *
+#from .ops import *
+#from .prettyprint_ops import *
+#from .script_ops import *
+#from .sort_ops import *
+from .variables import *
+# pylint: enable=wildcard-import

--- a/tensornets/contrib_framework/arg_scope.py
+++ b/tensornets/contrib_framework/arg_scope.py
@@ -1,0 +1,211 @@
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Contains the arg_scope used for scoping layers arguments.
+
+  Allows one to define models much more compactly by eliminating boilerplate
+  code. This is accomplished through the use of argument scoping (arg_scope).
+
+  Example of how to use tf.contrib.framework.arg_scope:
+
+  ```
+  from third_party.tensorflow.contrib.layers.python import layers
+
+  arg_scope = tf.contrib.framework.arg_scope
+
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)):
+    net = layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID', scope='conv1')
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+  The first call to conv2d will behave as follows:
+    layers.conv2d(inputs, 64, [11, 11], 4, padding='VALID',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv1')
+
+  The second call to conv2d will also use the arg_scope's default for padding:
+    layers.conv2d(inputs, 256, [5, 5], padding='SAME',
+                  initializer=layers.variance_scaling_initializer(),
+                  regularizer=layers.l2_regularizer(0.05), scope='conv2')
+
+  Example of how to reuse an arg_scope:
+
+  ```
+  with arg_scope([layers.conv2d], padding='SAME',
+                 initializer=layers.variance_scaling_initializer(),
+                 regularizer=layers.l2_regularizer(0.05)) as sc:
+    net = layers.conv2d(net, 256, [5, 5], scope='conv1')
+    ....
+
+  with arg_scope(sc):
+    net = layers.conv2d(net, 256, [5, 5], scope='conv2')
+  ```
+
+  Example of how to use tf.contrib.framework.add_arg_scope to enable your
+  function to be called within an arg_scope later:
+
+  @tf.contrib.framework.add_arg_scope
+  def conv2d(*args, **kwargs)
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.util import tf_contextlib
+from tensorflow.python.util import tf_decorator
+
+__all__ = [
+    'arg_scope', 'add_arg_scope', 'current_arg_scope', 'has_arg_scope',
+    'arg_scoped_arguments', 'arg_scope_func_key'
+]
+
+_ARGSTACK = [{}]
+
+_DECORATED_OPS = {}
+
+
+def _get_arg_stack():
+  if _ARGSTACK:
+    return _ARGSTACK
+  else:
+    _ARGSTACK.append({})
+    return _ARGSTACK
+
+
+def current_arg_scope():
+  stack = _get_arg_stack()
+  return stack[-1]
+
+
+def arg_scope_func_key(op):
+  return getattr(op, '_key_op', str(op))
+
+
+def _name_op(op):
+  return (op.__module__, op.__name__)
+
+
+def _kwarg_names(func):
+  kwargs_length = len(func.__defaults__) if func.__defaults__ else 0
+  return func.__code__.co_varnames[-kwargs_length:func.__code__.co_argcount]
+
+
+def _add_op(op):
+  key_op = arg_scope_func_key(op)
+  _DECORATED_OPS[key_op] = _kwarg_names(op)
+
+
+@tf_contextlib.contextmanager
+def arg_scope(list_ops_or_scope, **kwargs):
+  """Stores the default arguments for the given set of list_ops.
+
+  For usage, please see examples at top of the file.
+
+  Args:
+    list_ops_or_scope: List or tuple of operations to set argument scope for or
+      a dictionary containing the current scope. When list_ops_or_scope is a
+      dict, kwargs must be empty. When list_ops_or_scope is a list or tuple,
+      then every op in it need to be decorated with @add_arg_scope to work.
+    **kwargs: keyword=value that will define the defaults for each op in
+              list_ops. All the ops need to accept the given set of arguments.
+
+  Yields:
+    the current_scope, which is a dictionary of {op: {arg: value}}
+  Raises:
+    TypeError: if list_ops is not a list or a tuple.
+    ValueError: if any op in list_ops has not be decorated with @add_arg_scope.
+  """
+  if isinstance(list_ops_or_scope, dict):
+    # Assumes that list_ops_or_scope is a scope that is being reused.
+    if kwargs:
+      raise ValueError('When attempting to re-use a scope by suppling a'
+                       'dictionary, kwargs must be empty.')
+    current_scope = list_ops_or_scope.copy()
+    try:
+      _get_arg_stack().append(current_scope)
+      yield current_scope
+    finally:
+      _get_arg_stack().pop()
+  else:
+    # Assumes that list_ops_or_scope is a list/tuple of ops with kwargs.
+    if not isinstance(list_ops_or_scope, (list, tuple)):
+      raise TypeError('list_ops_or_scope must either be a list/tuple or reused '
+                      'scope (i.e. dict)')
+    try:
+      current_scope = current_arg_scope().copy()
+      for op in list_ops_or_scope:
+        key = arg_scope_func_key(op)
+        if not has_arg_scope(op):
+          raise ValueError('%s is not decorated with @add_arg_scope',
+                           _name_op(op))
+        if key in current_scope:
+          current_kwargs = current_scope[key].copy()
+          current_kwargs.update(kwargs)
+          current_scope[key] = current_kwargs
+        else:
+          current_scope[key] = kwargs.copy()
+      _get_arg_stack().append(current_scope)
+      yield current_scope
+    finally:
+      _get_arg_stack().pop()
+
+
+def add_arg_scope(func):
+  """Decorates a function with args so it can be used within an arg_scope.
+
+  Args:
+    func: function to decorate.
+
+  Returns:
+    A tuple with the decorated function func_with_args().
+  """
+
+  def func_with_args(*args, **kwargs):
+    current_scope = current_arg_scope()
+    current_args = kwargs
+    key_func = arg_scope_func_key(func)
+    if key_func in current_scope:
+      current_args = current_scope[key_func].copy()
+      current_args.update(kwargs)
+    return func(*args, **current_args)
+
+  _add_op(func)
+  setattr(func_with_args, '_key_op', arg_scope_func_key(func))
+  return tf_decorator.make_decorator(func, func_with_args)
+
+
+def has_arg_scope(func):
+  """Checks whether a func has been decorated with @add_arg_scope or not.
+
+  Args:
+    func: function to check.
+
+  Returns:
+    a boolean.
+  """
+  return arg_scope_func_key(func) in _DECORATED_OPS
+
+
+def arg_scoped_arguments(func):
+  """Returns the list kwargs that arg_scope can set for a func.
+
+  Args:
+    func: function which has been decorated with @add_arg_scope.
+
+  Returns:
+    a list of kwargs names.
+  """
+  assert has_arg_scope(func)
+  return _DECORATED_OPS[arg_scope_func_key(func)]

--- a/tensornets/contrib_framework/variables.py
+++ b/tensornets/contrib_framework/variables.py
@@ -1,0 +1,852 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Variable functions."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import re
+
+from .arg_scope import add_arg_scope as contrib_add_arg_scope
+from tensorflow.core.protobuf import saver_pb2
+from tensorflow.python import pywrap_tensorflow
+from tensorflow.python.framework import device as tf_device
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import resource_loader
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.training import saver as tf_saver
+from tensorflow.python.training import training_util
+from tensorflow.python.util.deprecation import deprecated
+
+
+__all__ = ['add_model_variable',
+           'assert_global_step',
+           'assert_or_get_global_step',
+           'assign_from_checkpoint',
+           'assign_from_checkpoint_fn',
+           'assign_from_values',
+           'assign_from_values_fn',
+           'create_global_step',
+           'filter_variables',
+           'get_global_step',
+           'get_or_create_global_step',
+           'get_local_variables',
+           'get_model_variables',
+           'get_trainable_variables',
+           'get_unique_variable',
+           'get_variables_by_name',
+           'get_variables_by_suffix',
+           'get_variable_full_name',
+           'get_variables_to_restore',
+           'get_variables',
+           'global_variable',
+           'local_variable',
+           'model_variable',
+           'variable',
+           'VariableDeviceChooser']
+
+
+@deprecated(None, 'Please switch to tf.train.assert_global_step')
+def assert_global_step(global_step_tensor):
+  training_util.assert_global_step(global_step_tensor)
+
+
+def assert_or_get_global_step(graph=None, global_step_tensor=None):
+  """Verifies that a global step tensor is valid or gets one if None is given.
+
+  If `global_step_tensor` is not None, check that it is a valid global step
+  tensor (using `assert_global_step`). Otherwise find a global step tensor using
+  `get_global_step` and return it.
+
+  Args:
+    graph: The graph to find the global step tensor for.
+    global_step_tensor: The tensor to check for suitability as a global step. If
+      None is given (the default), find a global step tensor.
+
+  Returns:
+    A tensor suitable as a global step, or `None` if none was provided and none
+    was found.
+  """
+  if global_step_tensor is None:
+    # Get the global step tensor the same way the supervisor would.
+    global_step_tensor = get_global_step(graph)
+  else:
+    assert_global_step(global_step_tensor)
+  return global_step_tensor
+
+
+@deprecated(None, 'Please switch to tf.train.get_global_step')
+def get_global_step(graph=None):
+  return training_util.get_global_step(graph)
+
+
+@deprecated(None, 'Please switch to tf.train.create_global_step')
+def create_global_step(graph=None):
+  """Create global step tensor in graph.
+
+  This API is deprecated. Use core framework training version instead.
+
+  Args:
+    graph: The graph in which to create the global step tensor. If missing, use
+      default graph.
+
+  Returns:
+    Global step tensor.
+
+  Raises:
+    ValueError: if global step tensor is already defined.
+  """
+  return training_util.create_global_step(graph)
+
+
+@deprecated(None, 'Please switch to tf.train.get_or_create_global_step')
+def get_or_create_global_step(graph=None):
+  """Returns and create (if necessary) the global step tensor.
+
+  Args:
+    graph: The graph in which to create the global step tensor. If missing, use
+      default graph.
+
+  Returns:
+    The global step tensor.
+  """
+  return training_util.get_or_create_global_step(graph)
+
+
+def local_variable(initial_value,
+                   validate_shape=True,
+                   name=None,
+                   use_resource=None):
+  """Create a variable with a value and add it to `GraphKeys.LOCAL_VARIABLES`.
+
+  Args:
+    initial_value: See variables.Variable.__init__.
+    validate_shape: See variables.Variable.__init__.
+    name: See variables.Variable.__init__.
+    use_resource: If `True` use a ResourceVariable instead of a Variable.
+
+  Returns:
+    New variable.
+  """
+  return variable_scope.variable(
+      initial_value,
+      trainable=False,
+      collections=[ops.GraphKeys.LOCAL_VARIABLES],
+      validate_shape=validate_shape,
+      use_resource=use_resource,
+      name=name)
+
+
+def global_variable(initial_value,
+                    validate_shape=True,
+                    name=None,
+                    use_resource=None):
+  """Create a variable with a value and add it to `GraphKeys.GLOBAL_VARIABLES`.
+
+  Args:
+    initial_value: See variables.Variable.__init__.
+    validate_shape: See variables.Variable.__init__.
+    name: See variables.Variable.__init__.
+    use_resource: If `True` use a ResourceVariable instead of a Variable.
+
+  Returns:
+    New variable.
+  """
+  return variable_scope.variable(
+      initial_value,
+      trainable=False,
+      collections=[ops.GraphKeys.GLOBAL_VARIABLES],
+      validate_shape=validate_shape,
+      use_resource=use_resource,
+      name=name)
+
+
+@contrib_add_arg_scope
+def variable(name,
+             shape=None,
+             dtype=None,
+             initializer=None,
+             regularizer=None,
+             trainable=True,
+             collections=None,
+             caching_device=None,
+             device=None,
+             partitioner=None,
+             custom_getter=None,
+             use_resource=None,
+             synchronization=variables.VariableSynchronization.AUTO,
+             aggregation=variables.VariableAggregation.NONE):
+  """Gets an existing variable with these parameters or creates a new one.
+
+  Args:
+    name: the name of the new or existing variable.
+    shape: shape of the new or existing variable.
+    dtype: type of the new or existing variable (defaults to `DT_FLOAT`).
+    initializer: initializer for the variable if one is created.
+    regularizer: a (Tensor -> Tensor or None) function; the result of applying
+      it on a newly created variable will be added to the collection
+      GraphKeys.REGULARIZATION_LOSSES and can be used for regularization.
+    trainable: If `True` also add the variable to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    collections: A list of collection names to which the Variable will be added.
+      If None it would default to `tf.GraphKeys.GLOBAL_VARIABLES`.
+    caching_device: Optional device string or function describing where the
+      Variable should be cached for reading.  Defaults to the Variable's device.
+    device: Optional device to place the variable. It can be an string or a
+      function that is called to get the device for the variable.
+    partitioner: Optional callable that accepts a fully defined `TensorShape`
+      and dtype of the `Variable` to be created, and returns a list of
+      partitions for each axis (currently only one axis can be partitioned).
+    custom_getter: Callable that allows overwriting the internal get_variable
+      method and has to have the same signature.
+    use_resource: If `True` use a ResourceVariable instead of a Variable.
+    synchronization: Indicates when a distributed a variable will be aggregated.
+      Accepted values are constants defined in the class
+      `tf.VariableSynchronization`. By default the synchronization is set to
+      `AUTO` and the current `DistributionStrategy` chooses when to synchronize.
+    aggregation: Indicates how a distributed variable will be aggregated.
+      Accepted values are constants defined in the class
+      `tf.VariableAggregation`.
+
+  Returns:
+    The created or existing variable.
+  """
+  collections = list(collections if collections is not None else
+                     [ops.GraphKeys.GLOBAL_VARIABLES])
+
+  # Remove duplicates
+  collections = list(set(collections))
+  getter = variable_scope.get_variable
+  if custom_getter is not None:
+    getter = functools.partial(
+        custom_getter, reuse=variable_scope.get_variable_scope().reuse)
+  with ops.device(device or ''):
+    return getter(
+        name,
+        shape=shape,
+        dtype=dtype,
+        initializer=initializer,
+        regularizer=regularizer,
+        trainable=trainable,
+        collections=collections,
+        caching_device=caching_device,
+        partitioner=partitioner,
+        use_resource=use_resource,
+        synchronization=synchronization,
+        aggregation=aggregation)
+
+
+@contrib_add_arg_scope
+def model_variable(name,
+                   shape=None,
+                   dtype=dtypes.float32,
+                   initializer=None,
+                   regularizer=None,
+                   trainable=True,
+                   collections=None,
+                   caching_device=None,
+                   device=None,
+                   partitioner=None,
+                   custom_getter=None,
+                   use_resource=None,
+                   synchronization=variables.VariableSynchronization.AUTO,
+                   aggregation=variables.VariableAggregation.NONE):
+  """Gets an existing model variable with these parameters or creates a new one.
+
+  Args:
+    name: the name of the new or existing variable.
+    shape: shape of the new or existing variable.
+    dtype: type of the new or existing variable (defaults to `DT_FLOAT`).
+    initializer: initializer for the variable if one is created.
+    regularizer: a (Tensor -> Tensor or None) function; the result of applying
+      it on a newly created variable will be added to the collection
+      GraphKeys.REGULARIZATION_LOSSES and can be used for regularization.
+    trainable: If `True` also add the variable to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    collections: A list of collection names to which the Variable will be added.
+      Note that the variable is always also added to the
+      `GraphKeys.GLOBAL_VARIABLES` and `GraphKeys.MODEL_VARIABLES` collections.
+    caching_device: Optional device string or function describing where the
+      Variable should be cached for reading.  Defaults to the Variable's device.
+    device: Optional device to place the variable. It can be an string or a
+      function that is called to get the device for the variable.
+    partitioner: Optional callable that accepts a fully defined `TensorShape`
+      and dtype of the `Variable` to be created, and returns a list of
+      partitions for each axis (currently only one axis can be partitioned).
+    custom_getter: Callable that allows overwriting the internal get_variable
+      method and has to have the same signature.
+    use_resource: If `True` use a ResourceVariable instead of a Variable.
+    synchronization: Indicates when a distributed a variable will be aggregated.
+      Accepted values are constants defined in the class
+      `tf.VariableSynchronization`. By default the synchronization is set to
+      `AUTO` and the current `DistributionStrategy` chooses when to synchronize.
+    aggregation: Indicates how a distributed variable will be aggregated.
+      Accepted values are constants defined in the class
+      `tf.VariableAggregation`.
+
+  Returns:
+    The created or existing variable.
+  """
+  collections = list(collections or [])
+  collections += [ops.GraphKeys.GLOBAL_VARIABLES, ops.GraphKeys.MODEL_VARIABLES]
+  var = variable(
+      name,
+      shape=shape,
+      dtype=dtype,
+      initializer=initializer,
+      regularizer=regularizer,
+      trainable=trainable,
+      collections=collections,
+      caching_device=caching_device,
+      device=device,
+      partitioner=partitioner,
+      custom_getter=custom_getter,
+      use_resource=use_resource,
+      synchronization=synchronization,
+      aggregation=aggregation)
+  return var
+
+
+def add_model_variable(var):
+  """Adds a variable to the `GraphKeys.MODEL_VARIABLES` collection.
+
+  Args:
+    var: a variable.
+  """
+  if var not in ops.get_collection(ops.GraphKeys.MODEL_VARIABLES):
+    ops.add_to_collection(ops.GraphKeys.MODEL_VARIABLES, var)
+
+
+def get_variables(scope=None,
+                  suffix=None,
+                  collection=ops.GraphKeys.GLOBAL_VARIABLES):
+  """Gets the list of variables, filtered by scope and/or suffix.
+
+  Args:
+    scope: an optional scope for filtering the variables to return. Can be a
+      variable scope or a string.
+    suffix: an optional suffix for filtering the variables to return.
+    collection: in which collection search for. Defaults to
+      `GraphKeys.GLOBAL_VARIABLES`.
+
+  Returns:
+    a list of variables in collection with scope and suffix.
+  """
+  if isinstance(scope, variable_scope.VariableScope):
+    scope = scope.name
+  if suffix is not None:
+    if ':' not in suffix:
+      suffix += ':'
+    scope = (scope or '') + '.*' + suffix
+  return ops.get_collection(collection, scope)
+
+
+def get_model_variables(scope=None, suffix=None):
+  """Gets the list of model variables, filtered by scope and/or suffix.
+
+  Args:
+    scope: an optional scope for filtering the variables to return.
+    suffix: an optional suffix for filtering the variables to return.
+
+  Returns:
+    a list of variables in collection with scope and suffix.
+  """
+  return get_variables(scope, suffix, ops.GraphKeys.MODEL_VARIABLES)
+
+
+def get_local_variables(scope=None, suffix=None):
+  """Gets the list of local variables, filtered by scope and/or suffix.
+
+  Args:
+    scope: an optional scope for filtering the variables to return.
+    suffix: an optional suffix for filtering the variables to return.
+
+  Returns:
+    a list of variables in collection with scope and suffix.
+  """
+  return get_variables(scope, suffix, ops.GraphKeys.LOCAL_VARIABLES)
+
+
+def get_trainable_variables(scope=None, suffix=None):
+  """Gets the list of trainable variables, filtered by scope and/or suffix.
+
+  Args:
+    scope: an optional scope for filtering the variables to return.
+    suffix: an optional suffix for filtering the variables to return.
+
+  Returns:
+    a list of variables in the trainable collection with scope and suffix.
+  """
+  return get_variables(scope, suffix, ops.GraphKeys.TRAINABLE_VARIABLES)
+
+
+def get_variables_to_restore(include=None, exclude=None):
+  """Gets the list of the variables to restore.
+
+  Args:
+    include: an optional list/tuple of scope strings for filtering which
+      variables from the VARIABLES collection to include. None would include all
+      the variables.
+    exclude: an optional list/tuple of scope strings for filtering which
+      variables from the VARIABLES collection to exclude. None it would not
+      exclude any.
+
+  Returns:
+    a list of variables to restore.
+
+  Raises:
+    TypeError: include or exclude is provided but is not a list or a tuple.
+  """
+  if include is None:
+    # Include all variables.
+    vars_to_include = get_variables()
+  else:
+    if not isinstance(include, (list, tuple)):
+      raise TypeError('include is provided but is not a list or a tuple.')
+    vars_to_include = []
+    for scope in include:
+      vars_to_include += get_variables(scope)
+  vars_to_exclude = set()
+  if exclude is not None:
+    if not isinstance(exclude, (list, tuple)):
+      raise TypeError('exclude is provided but is not a list or a tuple.')
+    for scope in exclude:
+      vars_to_exclude |= set(get_variables(scope))
+  # Exclude the variables in vars_to_exclude
+  return [v for v in vars_to_include if v not in vars_to_exclude]
+
+
+def get_variables_by_suffix(suffix, scope=None):
+  """Gets the list of variables that end with the given suffix.
+
+  Args:
+    suffix: suffix for filtering the variables to return.
+    scope: an optional scope for filtering the variables to return.
+
+  Returns:
+    a copied list of variables with the given name and prefix.
+  """
+  return get_variables(scope=scope, suffix=suffix)
+
+
+def get_variables_by_name(given_name, scope=None):
+  """Gets the list of variables that were given that name.
+
+  Args:
+    given_name: name given to the variable without any scope.
+    scope: an optional scope for filtering the variables to return.
+
+  Returns:
+    a copied list of variables with the given name and scope.
+  """
+  suffix = '/' + given_name + ':|^' + given_name + ':'
+  return get_variables(scope=scope, suffix=suffix)
+
+
+def get_unique_variable(var_op_name):
+  """Gets the variable uniquely identified by that var_op_name.
+
+  Args:
+    var_op_name: the full name of the variable op, including the scope.
+
+  Returns:
+    a tensorflow variable.
+
+  Raises:
+    ValueError: if no variable uniquely identified by the name exists.
+  """
+  candidates = get_variables(scope=var_op_name)
+  if not candidates:
+    raise ValueError('Couldn\'t find variable %s' % var_op_name)
+
+  for candidate in candidates:
+    if candidate.op.name == var_op_name:
+      return candidate
+  raise ValueError('Variable %s does not uniquely identify a variable' %
+                   var_op_name)
+
+
+def assign_from_values(var_names_to_values):
+  """Creates an assignment operation from a given mapping.
+
+  This function provides a mechanism for performing assignment of variables
+  to values in a way that does not fill the graph with large assignment values.
+
+  Args:
+    var_names_to_values: A map from variable names to values.
+
+  Returns:
+    assign_op: An `Operation` that assigns each of the given variables to the
+      requested values.
+    feed_dict: The feed dictionary to use when evaluating `assign_op`.
+
+  Raises:
+    ValueError: if any of the given variable names were not found.
+  """
+  feed_dict = {}
+  assign_ops = []
+
+  for var_name in var_names_to_values:
+    var_value = var_names_to_values[var_name]
+    var = ops.get_collection(ops.GraphKeys.GLOBAL_VARIABLES, var_name)
+    if not var:
+      raise ValueError('Variable %s wasn\'t found' % var_name)
+    elif len(var) > 1:
+      # tf.compat.v1.get_collection is just a filter on the prefix: find the exact match:
+      found = False
+      for v in var:
+        if v.op.name == var_name:
+          var = v
+          found = True
+          break
+
+      if not found:
+        raise ValueError('Variable %s doesn\'t uniquely identify a variable' %
+                         var_name)
+    else:
+      var = var[0]
+
+    # TODO(nsilberman): ensure placeholder and assign are on the same device.
+    # Assign a placeholder to the value that will be filled later.
+    placeholder_name = 'placeholder/' + var.op.name
+    placeholder_value = array_ops.placeholder(
+        dtype=var.dtype.base_dtype,
+        shape=var.get_shape(),
+        name=placeholder_name)
+    assign_ops.append(var.assign(placeholder_value))
+
+    feed_dict[placeholder_value] = var_value.reshape(var.get_shape())
+
+  assign_op = control_flow_ops.group(*assign_ops)
+  return assign_op, feed_dict
+
+
+def assign_from_values_fn(var_names_to_values):
+  """Returns a function that assigns specific variables from the given values.
+
+  This function provides a mechanism for performing assignment of variables
+  to values in a way that does not fill the graph with large assignment values.
+
+  Args:
+    var_names_to_values: A map from variable names to values.
+
+  Returns:
+    A function that takes a single argument, a `tf.compat.v1.Session`, that
+    applies the
+    assignment operation.
+
+  Raises:
+    ValueError: if any of the given variable names were not found.
+  """
+  assign_op, feed_dict = assign_from_values(var_names_to_values)
+
+  def callback(session):
+    return session.run(assign_op, feed_dict)
+
+  return callback
+
+
+# pylint: disable=protected-access
+# Currently variable_scope doesn't provide very good APIs to access
+# all variables under scope and retrieve and check existing scopes.
+def get_variable_full_name(var):
+  """Returns the full name of a variable.
+
+  For normal Variables, this is the same as the var.op.name.  For
+  sliced or PartitionedVariables, this name is the same for all the
+  slices/partitions. In both cases, this is normally the name used in
+  a checkpoint file.
+
+  Args:
+    var: A `Variable` object.
+
+  Returns:
+    A string that is the full name.
+  """
+  if var._save_slice_info:
+    return var._save_slice_info.full_name
+  else:
+    return var.op.name
+
+
+# TODO(nsilberman): add flag to load exponential moving averages instead
+#
+# TODO(sguada): Update docs in slim/g3doc/index.md to describe
+# the new feature where the var_list dictionary can have values that
+# are each a list of Variables.
+def assign_from_checkpoint(model_path, var_list, ignore_missing_vars=False):
+  """Creates an operation to assign specific variables from a checkpoint.
+
+  Args:
+    model_path: The full path to the model checkpoint. To get latest checkpoint
+      use `model_path = tf.train.latest_checkpoint(checkpoint_dir)`
+    var_list: A list of (possibly partitioned) `Variable` objects or a
+      dictionary mapping names in the checkpoint to the corresponding variables
+      or list of variables to initialize from that checkpoint value. For
+      partitioned Variables, the name in the checkpoint must be the full
+      variable, not the name of the partitioned variable, eg. "my_var" rather
+      than "my_var/part_4". If empty, returns no_op(), {}.
+    ignore_missing_vars: Boolean, if True ignore variables missing in the
+      checkpoint with a warning instead of failing.
+
+  Returns:
+    the restore_op and the feed_dict that need to be run to restore var_list.
+
+  Raises:
+    ValueError: If `ignore_missing_vars` is False and the checkpoint specified
+        at `model_path` is missing one of the variables in `var_list`.
+  """
+  # Normalize var_list into a dictionary mapping names in the
+  # checkpoint to the list of variables to initialize from that
+  # checkpoint variable. Sliced (including partitioned) variables will
+  # end up under the same key.
+  grouped_vars = {}
+  if isinstance(var_list, (tuple, list)):
+    for var in var_list:
+      ckpt_name = get_variable_full_name(var)
+      if ckpt_name not in grouped_vars:
+        grouped_vars[ckpt_name] = []
+      grouped_vars[ckpt_name].append(var)
+
+  else:
+    for ckpt_name, value in var_list.items():
+      if isinstance(value, (tuple, list)):
+        grouped_vars[ckpt_name] = value
+      else:
+        grouped_vars[ckpt_name] = [value]
+
+  # Read each checkpoint entry. Create a placeholder variable and
+  # add the (possibly sliced) data from the checkpoint to the feed_dict.
+  reader = pywrap_tensorflow.NewCheckpointReader(model_path)
+  feed_dict = {}
+  assign_ops = []
+  for ckpt_name in grouped_vars:
+    if not reader.has_tensor(ckpt_name):
+      log_str = 'Checkpoint is missing variable [%s]' % ckpt_name
+      if ignore_missing_vars:
+        logging.warning(log_str)
+        continue
+      else:
+        raise ValueError(log_str)
+    ckpt_value = reader.get_tensor(ckpt_name)
+
+    for var in grouped_vars[ckpt_name]:
+      placeholder_tensor = array_ops.placeholder(
+          dtype=var.dtype.base_dtype,
+          shape=var.get_shape(),
+          name='placeholder/' + var.op.name)
+      assign_ops.append(var.assign(placeholder_tensor))
+
+      if not var._save_slice_info:
+        if var.get_shape() != ckpt_value.shape:
+          raise ValueError(
+              'Total size of new array must be unchanged for %s '
+              'lh_shape: [%s], rh_shape: [%s]' %
+              (ckpt_name, str(ckpt_value.shape), str(var.get_shape())))
+
+        feed_dict[placeholder_tensor] = ckpt_value.reshape(ckpt_value.shape)
+      else:
+        slice_dims = zip(var._save_slice_info.var_offset,
+                         var._save_slice_info.var_shape)
+        slice_dims = [(start, start + size) for (start, size) in slice_dims]
+        slice_dims = [slice(*x) for x in slice_dims]
+        slice_value = ckpt_value[slice_dims]
+        slice_value = slice_value.reshape(var._save_slice_info.var_shape)
+        feed_dict[placeholder_tensor] = slice_value
+
+  assign_op = control_flow_ops.group(*assign_ops)
+  return assign_op, feed_dict
+
+
+# pylint: enable=protected-access
+
+
+def assign_from_checkpoint_fn(model_path,
+                              var_list,
+                              ignore_missing_vars=False,
+                              reshape_variables=False):
+  """Returns a function that assigns specific variables from a checkpoint.
+
+  If ignore_missing_vars is True and no variables are found in the checkpoint
+  it returns None.
+
+  Args:
+    model_path: The full path to the model checkpoint. To get latest checkpoint
+      use `model_path = tf.train.latest_checkpoint(checkpoint_dir)`
+    var_list: A list of `Variable` objects or a dictionary mapping names in the
+      checkpoint to the corresponding variables to initialize. If empty or
+      `None`, it would return `no_op(), None`.
+    ignore_missing_vars: Boolean, if True it would ignore variables missing in
+      the checkpoint with a warning instead of failing.
+    reshape_variables: Boolean, if True it would automatically reshape variables
+      which are of different shape then the ones stored in the checkpoint but
+      which have the same number of elements.
+
+  Returns:
+    A function that takes a single argument, a `tf.compat.v1.Session`, that
+    applies the
+    assignment operation. If no matching variables were found in the checkpoint
+    then `None` is returned.
+
+  Raises:
+    ValueError: If var_list is empty.
+  """
+  if not var_list:
+    raise ValueError('var_list cannot be empty')
+  if ignore_missing_vars:
+    reader = pywrap_tensorflow.NewCheckpointReader(model_path)
+    if isinstance(var_list, dict):
+      var_dict = var_list
+    else:
+      var_dict = {var.op.name: var for var in var_list}
+    available_vars = {}
+    for var in var_dict:
+      if reader.has_tensor(var):
+        available_vars[var] = var_dict[var]
+      else:
+        logging.warning('Variable %s missing in checkpoint %s', var, model_path)
+    var_list = available_vars
+  if var_list:
+    saver = tf_saver.Saver(
+        var_list,
+        reshape=reshape_variables,
+        write_version=saver_pb2.SaverDef.V1)
+
+    def callback(session):
+      saver.restore(session, model_path)
+
+    return callback
+  else:
+    logging.warning('No Variables to restore')
+    return None
+
+
+class VariableDeviceChooser(object):
+  """Device chooser for variables.
+
+  When using a parameter server it will assign them in a round-robin fashion.
+  When not using a parameter server it allows GPU or CPU placement.
+  """
+
+  def __init__(self,
+               num_tasks=0,
+               job_name='ps',
+               device_type='CPU',
+               device_index=0,
+               replica=None):
+    """Initialize VariableDeviceChooser.
+
+    Usage:
+      To use with 2 parameter servers:
+        VariableDeviceChooser(2)
+
+      To use without parameter servers:
+        VariableDeviceChooser()
+        VariableDeviceChooser(device_type='GPU') # For GPU placement
+
+    Args:
+      num_tasks: number of tasks.
+      job_name: String, a name for the parameter server job.
+      device_type: Optional device type string (e.g. "CPU" or "GPU")
+      device_index: int.  Optional device index.  If left unspecified, device
+        represents 'any' device_index.
+    """
+    self._job_name = job_name
+    self._device_type = device_type
+    self._device_index = device_index
+    self._replica = replica
+    self._num_tasks = num_tasks
+    self._next_task_id = 0
+
+  def __call__(self, op):
+    device_spec = tf_device.DeviceSpec(
+        replica=self._replica,
+        device_type=self._device_type,
+        device_index=self._device_index)
+    if self._num_tasks > 0:
+      task_id = self._next_task_id
+      self._next_task_id = (self._next_task_id + 1) % self._num_tasks
+      device_spec.job = self._job_name
+      device_spec.task = task_id
+    return device_spec.to_string()
+
+
+def filter_variables(var_list,
+                     include_patterns=None,
+                     exclude_patterns=None,
+                     reg_search=True):
+  """Filter a list of variables using regular expressions.
+
+  First includes variables according to the list of include_patterns.
+  Afterwards, eliminates variables according to the list of exclude_patterns.
+
+  For example, one can obtain a list of variables with the weights of all
+  convolutional layers (depending on the network definition) by:
+
+  ```python
+  variables = tf.contrib.framework.get_model_variables()
+  conv_weight_variables = tf.contrib.framework.filter_variables(
+      variables,
+      include_patterns=['Conv'],
+      exclude_patterns=['biases', 'Logits'])
+  ```
+
+  Args:
+    var_list: list of variables.
+    include_patterns: list of regular expressions to include. Defaults to None,
+      which means all variables are selected according to the include rules. A
+      variable is included if it matches any of the include_patterns.
+    exclude_patterns: list of regular expressions to exclude. Defaults to None,
+      which means all variables are selected according to the exclude rules. A
+      variable is excluded if it matches any of the exclude_patterns.
+    reg_search: boolean. If True (default), performs re.search to find matches
+      (i.e. pattern can match any substring of the variable name). If False,
+      performs re.match (i.e. regexp should match from the beginning of the
+      variable name).
+
+  Returns:
+    filtered list of variables.
+  """
+  if reg_search:
+    reg_exp_func = re.search
+  else:
+    reg_exp_func = re.match
+
+  # First include variables.
+  if include_patterns is None:
+    included_variables = list(var_list)
+  else:
+    included_variables = []
+    for var in var_list:
+      if any(reg_exp_func(ptrn, var.name) for ptrn in include_patterns):
+        included_variables.append(var)
+
+  # Afterwards, exclude variables.
+  if exclude_patterns is None:
+    filtered_variables = included_variables
+  else:
+    filtered_variables = []
+    for var in included_variables:
+      if not any(reg_exp_func(ptrn, var.name) for ptrn in exclude_patterns):
+        filtered_variables.append(var)
+
+  return filtered_variables

--- a/tensornets/contrib_layers/__init__.py
+++ b/tensornets/contrib_layers/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""layers module with higher level NN primitives."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# pylint: disable=wildcard-import
+#from .embedding_ops import *
+#from .encoders import *
+#from .feature_column import *
+#from .feature_column_ops import *
+from .initializers import *
+from .layers import *
+from .normalization import *
+from .optimizers import *
+from .regularizers import *
+from .rev_block_lib import *
+from .summaries import *
+#from .target_column import *
+#from tensorflow.contrib.layers.python.ops.bucketization_op import *
+#from tensorflow.contrib.layers.python.ops.sparse_feature_cross_op import *
+# pylint: enable=wildcard-import

--- a/tensornets/contrib_layers/initializers.py
+++ b/tensornets/contrib_layers/initializers.py
@@ -1,0 +1,153 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Weight initializers for use with layers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import math
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.ops import random_ops
+
+
+__all__ = ['xavier_initializer', 'xavier_initializer_conv2d',
+           'variance_scaling_initializer']
+
+
+def xavier_initializer(uniform=True, seed=None, dtype=dtypes.float32):
+  """Returns an initializer performing "Xavier" initialization for weights.
+
+  This function implements the weight initialization from:
+
+  Xavier Glorot and Yoshua Bengio (2010):
+           [Understanding the difficulty of training deep feedforward neural
+           networks. International conference on artificial intelligence and
+           statistics.](
+           http://www.jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf)
+
+  This initializer is designed to keep the scale of the gradients roughly the
+  same in all layers. In uniform distribution this ends up being the range:
+  `x = sqrt(6. / (in + out)); [-x, x]` and for normal distribution a standard
+  deviation of `sqrt(2. / (in + out))` is used.
+
+  Args:
+    uniform: Whether to use uniform or normal distributed random initialization.
+    seed: A Python integer. Used to create random seeds. See
+          `tf.compat.v1.set_random_seed` for behavior.
+    dtype: The data type. Only floating point types are supported.
+
+  Returns:
+    An initializer for a weight matrix.
+  """
+  return variance_scaling_initializer(factor=1.0, mode='FAN_AVG',
+                                      uniform=uniform, seed=seed, dtype=dtype)
+
+xavier_initializer_conv2d = xavier_initializer
+
+
+def variance_scaling_initializer(factor=2.0, mode='FAN_IN', uniform=False,
+                                 seed=None, dtype=dtypes.float32):
+  """Returns an initializer that generates tensors without scaling variance.
+
+  When initializing a deep network, it is in principle advantageous to keep
+  the scale of the input variance constant, so it does not explode or diminish
+  by reaching the final layer. This initializer use the following formula:
+
+  ```python
+    if mode='FAN_IN': # Count only number of input connections.
+      n = fan_in
+    elif mode='FAN_OUT': # Count only number of output connections.
+      n = fan_out
+    elif mode='FAN_AVG': # Average number of inputs and output connections.
+      n = (fan_in + fan_out)/2.0
+
+      truncated_normal(shape, 0.0, stddev=sqrt(factor / n))
+  ```
+
+  * To get [Delving Deep into Rectifiers](
+     http://arxiv.org/pdf/1502.01852v1.pdf) (also know as the "MSRA 
+     initialization"), use (Default):<br/>
+    `factor=2.0 mode='FAN_IN' uniform=False`
+  * To get [Convolutional Architecture for Fast Feature Embedding](
+     http://arxiv.org/abs/1408.5093), use:<br/>
+    `factor=1.0 mode='FAN_IN' uniform=True`
+  * To get [Understanding the difficulty of training deep feedforward neural
+    networks](http://jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf),
+    use:<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=True.`
+  * To get `xavier_initializer` use either:<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=True`, or<br/>
+    `factor=1.0 mode='FAN_AVG' uniform=False`.
+
+  Args:
+    factor: Float.  A multiplicative factor.
+    mode: String.  'FAN_IN', 'FAN_OUT', 'FAN_AVG'.
+    uniform: Whether to use uniform or normal distributed random initialization.
+    seed: A Python integer. Used to create random seeds. See
+          `tf.compat.v1.set_random_seed` for behavior.
+    dtype: The data type. Only floating point types are supported.
+
+  Returns:
+    An initializer that generates tensors with unit variance.
+
+  Raises:
+    ValueError: if `dtype` is not a floating point type.
+    TypeError: if `mode` is not in ['FAN_IN', 'FAN_OUT', 'FAN_AVG'].
+  """
+  if not dtype.is_floating:
+    raise TypeError('Cannot create initializer for non-floating point type.')
+  if mode not in ['FAN_IN', 'FAN_OUT', 'FAN_AVG']:
+    raise TypeError('Unknown mode %s [FAN_IN, FAN_OUT, FAN_AVG]', mode)
+
+  # pylint: disable=unused-argument
+  def _initializer(shape, dtype=dtype, partition_info=None):
+    """Initializer function."""
+    if not dtype.is_floating:
+      raise TypeError('Cannot create initializer for non-floating point type.')
+    # Estimating fan_in and fan_out is not possible to do perfectly, but we try.
+    # This is the right thing for matrix multiply and convolutions.
+    if shape:
+      fan_in = float(shape[-2]) if len(shape) > 1 else float(shape[-1])
+      fan_out = float(shape[-1])
+    else:
+      fan_in = 1.0
+      fan_out = 1.0
+    for dim in shape[:-2]:
+      fan_in *= float(dim)
+      fan_out *= float(dim)
+    if mode == 'FAN_IN':
+      # Count only number of input connections.
+      n = fan_in
+    elif mode == 'FAN_OUT':
+      # Count only number of output connections.
+      n = fan_out
+    elif mode == 'FAN_AVG':
+      # Average number of inputs and output connections.
+      n = (fan_in + fan_out) / 2.0
+    if uniform:
+      # To get stddev = math.sqrt(factor / n) need to adjust for uniform.
+      limit = math.sqrt(3.0 * factor / n)
+      return random_ops.random_uniform(shape, -limit, limit,
+                                       dtype, seed=seed)
+    else:
+      # To get stddev = math.sqrt(factor / n) need to adjust for truncated.
+      trunc_stddev = math.sqrt(1.3 * factor / n)
+      return random_ops.truncated_normal(shape, 0.0, trunc_stddev, dtype,
+                                         seed=seed)
+  # pylint: enable=unused-argument
+
+  return _initializer

--- a/tensornets/contrib_layers/layers.py
+++ b/tensornets/contrib_layers/layers.py
@@ -1,0 +1,3336 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# pylint: disable=g-short-docstring-punctuation
+"""Higher level ops for building layers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import six
+
+from ..contrib_framework import add_arg_scope
+from ..contrib_framework import variables
+from . import initializers
+from . import utils
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import function
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import sparse_tensor
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.keras.engine import input_spec
+from tensorflow.python.layers import base
+from tensorflow.python.layers import convolutional as convolutional_layers
+from tensorflow.python.layers import core as core_layers
+from tensorflow.python.layers import normalization as normalization_layers
+from tensorflow.python.layers import pooling as pooling_layers
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import check_ops
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import linalg_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+from tensorflow.python.ops import sparse_ops
+from tensorflow.python.ops import standard_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops import variables as tf_variables
+from tensorflow.python.training import moving_averages
+
+# TODO(b/28426988): Replace legacy_* fns migrated from slim.
+# TODO(b/28426988): Remove legacy_* when all uses have migrated to new API.
+__all__ = [
+    'avg_pool2d', 'avg_pool3d', 'batch_norm', 'bias_add', 'conv1d', 'conv2d',
+    'conv3d', 'conv2d_in_plane', 'conv2d_transpose', 'conv3d_transpose',
+    'convolution', 'convolution1d', 'convolution2d', 'convolution2d_in_plane',
+    'convolution2d_transpose', 'convolution3d', 'convolution3d_transpose',
+    'dense_to_sparse', 'dropout', 'elu', 'flatten', 'fully_connected', 'GDN',
+    'gdn', 'images_to_sequence', 'layer_norm', 'linear', 'pool', 'max_pool2d',
+    'max_pool3d', 'one_hot_encoding', 'relu', 'relu6', 'repeat',
+    'scale_gradient', 'separable_conv2d', 'separable_convolution2d',
+    'sequence_to_images', 'softmax', 'spatial_softmax', 'stack', 'unit_norm',
+    'legacy_fully_connected', 'legacy_linear', 'legacy_relu', 'maxout'
+]
+
+DATA_FORMAT_NCHW = 'NCHW'
+DATA_FORMAT_NHWC = 'NHWC'
+DATA_FORMAT_NCDHW = 'NCDHW'
+DATA_FORMAT_NDHWC = 'NDHWC'
+
+
+@add_arg_scope
+def avg_pool2d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NHWC,
+               outputs_collections=None,
+               scope=None):
+  """Adds a 2D average pooling op.
+
+  It is assumed that the pooling is done per image but not in batch or channels.
+
+  Args:
+    inputs: A 4-D tensor of shape `[batch_size, height, width, channels]` if
+      `data_format` is `NHWC`, and `[batch_size, channels, height, width]` if
+      `data_format` is `NCHW`.
+    kernel_size: A list of length 2: [kernel_height, kernel_width] of the
+      pooling kernel over which the op is computed. Can be an int if both values
+      are the same.
+    stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+      both strides are the same. Note that presently both strides must have the
+      same value.
+    padding: The padding method, either 'VALID' or 'SAME'.
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  with ops.name_scope(scope, 'AvgPool2D', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = pooling_layers.AveragePooling2D(
+        pool_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        _scope=sc)
+    outputs = layer.apply(inputs)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def avg_pool3d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NDHWC,
+               outputs_collections=None,
+               scope=None):
+  """Adds a 3D average pooling op.
+
+  It is assumed that the pooling is done per image but not in batch or channels.
+
+  Args:
+    inputs: A 5-D tensor of shape `[batch_size, depth, height, width, channels]`
+      if `data_format` is `NDHWC`, and `[batch_size, channels, depth, height,
+      width]` if `data_format` is `NCDHW`.
+    kernel_size: A list of length 3: [kernel_depth, kernel_height, kernel_width]
+      of the pooling kernel over which the op is computed. Can be an int if both
+      values are the same.
+    stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+      be an int if both strides are the same. Note that presently both strides
+      must have the same value.
+    padding: The padding method, either 'VALID' or 'SAME'.
+    data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+  """
+  if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+    raise ValueError('data_format has to be either NCDHW or NDHWC.')
+  with ops.name_scope(scope, 'AvgPool3D', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = pooling_layers.AveragePooling3D(
+        pool_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        _scope=sc)
+    outputs = layer.apply(inputs)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _fused_batch_norm(inputs,
+                      decay=0.999,
+                      center=True,
+                      scale=False,
+                      epsilon=0.001,
+                      activation_fn=None,
+                      param_initializers=None,
+                      param_regularizers=None,
+                      updates_collections=ops.GraphKeys.UPDATE_OPS,
+                      is_training=True,
+                      reuse=None,
+                      variables_collections=None,
+                      outputs_collections=None,
+                      trainable=True,
+                      data_format=DATA_FORMAT_NHWC,
+                      zero_debias_moving_mean=False,
+                      scope=None):
+  """Adds a Batch Normalization layer from http://arxiv.org/abs/1502.03167.
+
+    "Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift"
+
+    Sergey Ioffe, Christian Szegedy
+
+  Can be used as a normalizer function for conv2d and fully_connected.
+
+  Note: when training, the moving_mean and moving_variance need to be updated.
+  By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+  need to be added as a dependency to the `train_op`. For example:
+
+  ```python
+    update_ops = tf.compat.v1.get_collection(tf.GraphKeys.UPDATE_OPS)
+    with tf.control_dependencies(update_ops):
+      train_op = optimizer.minimize(loss)
+  ```
+
+  One can set updates_collections=None to force the updates in place, but that
+  can have a speed penalty, especially in distributed settings.
+
+  Args:
+    inputs: A tensor with 2 or more dimensions, where the first dimension has
+      `batch_size`. The normalization is over all but the last dimension if
+      `data_format` is `NHWC` and the second dimension if `data_format` is
+      `NCHW`.
+    decay: Decay for the moving average. Reasonable values for `decay` are close
+      to 1.0, typically in the multiple-nines range: 0.999, 0.99, 0.9, etc.
+        Lower `decay` value (recommend trying `decay`=0.9) if model experiences
+        reasonably good training performance but poor validation and/or test
+        performance.
+    center: If True, add offset of `beta` to normalized tensor.  If False,
+      `beta` is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+      next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+      scaling can be done by the next layer.
+    epsilon: Small float added to variance to avoid dividing by zero.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    param_initializers: Optional initializers for beta, gamma, moving mean and
+      moving variance.
+    param_regularizers: Optional regularizer for beta and gamma.
+    updates_collections: Collections to collect the update ops for computation.
+      The updates_ops need to be executed with the train_op. If None, a control
+      dependency would be added to make sure the updates are computed in place.
+    is_training: Whether or not the layer is in training mode. In training mode
+      it would accumulate the statistics of the moments into `moving_mean` and
+      `moving_variance` using an exponential moving average with the given
+      `decay`. When it is not in training mode then it would use the values of
+      the `moving_mean` and the `moving_variance`.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    zero_debias_moving_mean: Use zero_debias for moving_mean.
+    scope: Optional scope for `variable_scope`.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If the rank of `inputs` is undefined.
+    ValueError: If the rank of `inputs` is neither 2 or 4.
+    ValueError: If rank or `C` dimension of `inputs` is undefined.
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  with variable_scope.variable_scope(
+      scope, 'BatchNorm', [inputs], reuse=reuse) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    original_shape = inputs.get_shape()
+    original_inputs = inputs
+    original_rank = original_shape.ndims
+    if original_rank is None:
+      raise ValueError('Inputs %s has undefined rank' % inputs.name)
+    elif original_rank not in [2, 4]:
+      raise ValueError('Inputs %s has unsupported rank.'
+                       ' Expected 2 or 4 but got %d' %
+                       (inputs.name, original_rank))
+    if original_rank == 2:
+      channels = inputs.get_shape().dims[-1].value
+      if channels is None:
+        raise ValueError('`C` dimension must be known but is None')
+      new_shape = [-1, 1, 1, channels]
+      if data_format == DATA_FORMAT_NCHW:
+        new_shape = [-1, channels, 1, 1]
+      inputs = array_ops.reshape(inputs, new_shape)
+    inputs_shape = inputs.get_shape()
+    if data_format == DATA_FORMAT_NHWC:
+      params_shape = inputs_shape[-1:]
+    else:
+      params_shape = inputs_shape[1:2]
+    if not params_shape.is_fully_defined():
+      raise ValueError('Inputs %s has undefined `C` dimension %s.' %
+                       (inputs.name, params_shape))
+
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta_collections = utils.get_variable_collections(variables_collections,
+                                                      'beta')
+    # Float32 required to avoid precision-loss when using fp16 input/output
+    variable_dtype = dtypes.float32
+    if not param_initializers:
+      param_initializers = {}
+    if not param_regularizers:
+      param_regularizers = {}
+    beta_regularizer = param_regularizers.get('beta')
+    gamma_regularizer = param_regularizers.get('gamma')
+
+    if center:
+      beta_initializer = param_initializers.get('beta',
+                                                init_ops.zeros_initializer())
+      beta = variables.model_variable(
+          'beta',
+          shape=params_shape,
+          dtype=variable_dtype,
+          initializer=beta_initializer,
+          regularizer=beta_regularizer,
+          collections=beta_collections,
+          trainable=trainable)
+    else:
+      beta = array_ops.constant(0.0, dtype=variable_dtype, shape=params_shape)
+
+    if scale:
+      gamma_collections = utils.get_variable_collections(
+          variables_collections, 'gamma')
+      gamma_initializer = param_initializers.get('gamma',
+                                                 init_ops.ones_initializer())
+      gamma = variables.model_variable(
+          'gamma',
+          shape=params_shape,
+          dtype=variable_dtype,
+          initializer=gamma_initializer,
+          regularizer=gamma_regularizer,
+          collections=gamma_collections,
+          trainable=trainable)
+    else:
+      gamma = array_ops.constant(1.0, dtype=variable_dtype, shape=params_shape)
+
+    # Create moving_mean and moving_variance variables and add them to the
+    # appropriate collections. We disable variable partitioning while creating
+    # them, because assign_moving_average is not yet supported for partitioned
+    # variables (this needs to be handled carefully, as it may break
+    # the checkpoint backward compatibility).
+    with variable_scope.variable_scope(
+        variable_scope.get_variable_scope()) as local_scope:
+      local_scope.set_partitioner(None)
+      moving_mean_collections = utils.get_variable_collections(
+          variables_collections, 'moving_mean')
+      moving_mean_initializer = param_initializers.get(
+          'moving_mean', init_ops.zeros_initializer())
+      moving_mean = variables.model_variable(
+          'moving_mean',
+          shape=params_shape,
+          dtype=variable_dtype,
+          initializer=moving_mean_initializer,
+          trainable=False,
+          collections=moving_mean_collections)
+      moving_variance_collections = utils.get_variable_collections(
+          variables_collections, 'moving_variance')
+      moving_variance_initializer = param_initializers.get(
+          'moving_variance', init_ops.ones_initializer())
+      moving_variance = variables.model_variable(
+          'moving_variance',
+          shape=params_shape,
+          dtype=variable_dtype,
+          initializer=moving_variance_initializer,
+          trainable=False,
+          collections=moving_variance_collections)
+
+    def _fused_batch_norm_training():
+      return nn.fused_batch_norm(
+          inputs, gamma, beta, epsilon=epsilon, data_format=data_format)
+
+    def _fused_batch_norm_inference():
+      return nn.fused_batch_norm(
+          inputs,
+          gamma,
+          beta,
+          mean=moving_mean,
+          variance=moving_variance,
+          epsilon=epsilon,
+          is_training=False,
+          data_format=data_format)
+
+    outputs, mean, variance = utils.smart_cond(is_training,
+                                               _fused_batch_norm_training,
+                                               _fused_batch_norm_inference)
+
+    # If `is_training` doesn't have a constant value, because it is a `Tensor`,
+    # a `Variable` or `Placeholder` then is_training_value will be None and
+    # `need_updates` will be true.
+    is_training_value = utils.constant_value(is_training)
+    need_updates = is_training_value is None or is_training_value
+    if need_updates:
+      if updates_collections is None:
+        no_updates = lambda: outputs
+
+        def _force_updates():
+          """Internal function forces updates moving_vars if is_training."""
+          update_moving_mean = moving_averages.assign_moving_average(
+              moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+          update_moving_variance = moving_averages.assign_moving_average(
+              moving_variance, variance, decay, zero_debias=False)
+          with ops.control_dependencies(
+              [update_moving_mean, update_moving_variance]):
+            return array_ops.identity(outputs)
+
+        outputs = utils.smart_cond(is_training, _force_updates, no_updates)
+      else:
+        moving_vars_fn = lambda: (moving_mean, moving_variance)
+
+        def _delay_updates():
+          """Internal function that delay updates moving_vars if is_training."""
+          update_moving_mean = moving_averages.assign_moving_average(
+              moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+          update_moving_variance = moving_averages.assign_moving_average(
+              moving_variance, variance, decay, zero_debias=False)
+          return update_moving_mean, update_moving_variance
+
+        update_mean, update_variance = utils.smart_cond(is_training,
+                                                        _delay_updates,
+                                                        moving_vars_fn)
+        ops.add_to_collections(updates_collections, update_mean)
+        ops.add_to_collections(updates_collections, update_variance)
+
+    outputs.set_shape(inputs_shape)
+    if original_shape.ndims == 2:
+      outputs = array_ops.reshape(outputs, array_ops.shape(original_inputs))
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def batch_norm(inputs,
+               decay=0.999,
+               center=True,
+               scale=False,
+               epsilon=0.001,
+               activation_fn=None,
+               param_initializers=None,
+               param_regularizers=None,
+               updates_collections=ops.GraphKeys.UPDATE_OPS,
+               is_training=True,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               batch_weights=None,
+               fused=None,
+               data_format=DATA_FORMAT_NHWC,
+               zero_debias_moving_mean=False,
+               scope=None,
+               renorm=False,
+               renorm_clipping=None,
+               renorm_decay=0.99,
+               adjustment=None):
+  """Adds a Batch Normalization layer from http://arxiv.org/abs/1502.03167.
+
+    "Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift"
+
+    Sergey Ioffe, Christian Szegedy
+
+  Can be used as a normalizer function for conv2d and fully_connected. The
+  normalization is over all but the last dimension if `data_format` is `NHWC`
+  and all but the second dimension if `data_format` is `NCHW`.  In case of a 2D
+  tensor this corresponds to the batch dimension, while in case of a 4D tensor
+  this
+  corresponds to the batch and space dimensions.
+
+  Note: when training, the moving_mean and moving_variance need to be updated.
+  By default the update ops are placed in `tf.GraphKeys.UPDATE_OPS`, so they
+  need to be added as a dependency to the `train_op`. For example:
+
+  ```python
+    update_ops = tf.compat.v1.get_collection(tf.GraphKeys.UPDATE_OPS)
+    with tf.control_dependencies(update_ops):
+      train_op = optimizer.minimize(loss)
+  ```
+
+  One can set updates_collections=None to force the updates in place, but that
+  can have a speed penalty, especially in distributed settings.
+
+  Args:
+    inputs: A tensor with 2 or more dimensions, where the first dimension has
+      `batch_size`. The normalization is over all but the last dimension if
+      `data_format` is `NHWC` and the second dimension if `data_format` is
+      `NCHW`.
+    decay: Decay for the moving average. Reasonable values for `decay` are close
+      to 1.0, typically in the multiple-nines range: 0.999, 0.99, 0.9, etc.
+        Lower `decay` value (recommend trying `decay`=0.9) if model experiences
+        reasonably good training performance but poor validation and/or test
+        performance. Try zero_debias_moving_mean=True for improved stability.
+    center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+      is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+      next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+      scaling can be done by the next layer.
+    epsilon: Small float added to variance to avoid dividing by zero.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    param_initializers: Optional initializers for beta, gamma, moving mean and
+      moving variance.
+    param_regularizers: Optional regularizer for beta and gamma.
+    updates_collections: Collections to collect the update ops for computation.
+      The updates_ops need to be executed with the train_op. If None, a control
+      dependency would be added to make sure the updates are computed in place.
+    is_training: Whether or not the layer is in training mode. In training mode
+      it would accumulate the statistics of the moments into `moving_mean` and
+      `moving_variance` using an exponential moving average with the given
+      `decay`. When it is not in training mode then it would use the values of
+      the `moving_mean` and the `moving_variance`.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    batch_weights: An optional tensor of shape `[batch_size]`, containing a
+      frequency weight for each batch item. If present, then the batch
+      normalization uses weighted mean and variance. (This can be used to
+      correct for bias in training example selection.)
+    fused: if `None` or `True`, use a faster, fused implementation if possible.
+      If `False`, use the system recommended implementation.
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    zero_debias_moving_mean: Use zero_debias for moving_mean. It creates a new
+      pair of variables 'moving_mean/biased' and 'moving_mean/local_step'.
+    scope: Optional scope for `variable_scope`.
+    renorm: Whether to use Batch Renormalization
+      (https://arxiv.org/abs/1702.03275). This adds extra variables during
+        training. The inference is the same for either value of this parameter.
+    renorm_clipping: A dictionary that may map keys 'rmax', 'rmin', 'dmax' to
+      scalar `Tensors` used to clip the renorm correction. The correction `(r,
+      d)` is used as `corrected_value = normalized_value * r + d`, with `r`
+      clipped to [rmin, rmax], and `d` to [-dmax, dmax]. Missing rmax, rmin,
+      dmax are set to inf, 0, inf, respectively.
+    renorm_decay: Momentum used to update the moving means and standard
+      deviations with renorm. Unlike `momentum`, this affects training and
+      should be neither too small (which would add noise) nor too large (which
+      would give stale estimates). Note that `decay` is still applied to get the
+      means and variances for inference.
+    adjustment: A function taking the `Tensor` containing the (dynamic) shape of
+      the input tensor and returning a pair (scale, bias) to apply to the
+      normalized values (before gamma and beta), only during training. For
+      example,
+        `adjustment = lambda shape: (
+          tf.random.uniform(shape[-1:], 0.93, 1.07),
+          tf.random.uniform(shape[-1:], -0.1, 0.1))` will scale the normalized
+            value by up to 7% up or down, then shift the result by up to 0.1
+            (with independent scaling and bias for each feature but shared
+            across all examples), and finally apply gamma and/or beta. If
+            `None`, no adjustment is applied.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If the rank of `inputs` is undefined.
+    ValueError: If rank or channels dimension of `inputs` is undefined.
+  """
+  if fused is None:
+    fused = True
+
+  # Only use _fused_batch_norm if all of the following three
+  # conditions are true:
+  # (1) fused is set True;
+  # (2) it is possible to use (currently it doesn't support batch weights,
+  #   renorm, and the case when rank is neither 2 nor 4);
+  # (3) it is used with zero_debias_moving_mean, or an input shape of rank 2,
+  #   or non-default updates_collections (not implemented in
+  #   normalization_layers.BatchNormalization yet); otherwise use the fused
+  #   implementation in normalization_layers.BatchNormalization.
+  inputs = ops.convert_to_tensor(inputs)
+  rank = inputs.get_shape().ndims
+  possible_to_fuse = (
+      batch_weights is None and not renorm and rank in [2, 4] and
+      adjustment is None)
+  if fused and possible_to_fuse and (
+      zero_debias_moving_mean or rank == 2 or
+      updates_collections is not ops.GraphKeys.UPDATE_OPS):
+    return _fused_batch_norm(
+        inputs,
+        decay=decay,
+        center=center,
+        scale=scale,
+        epsilon=epsilon,
+        activation_fn=activation_fn,
+        param_initializers=param_initializers,
+        param_regularizers=param_regularizers,
+        updates_collections=updates_collections,
+        is_training=is_training,
+        reuse=reuse,
+        variables_collections=variables_collections,
+        outputs_collections=outputs_collections,
+        trainable=trainable,
+        data_format=data_format,
+        zero_debias_moving_mean=zero_debias_moving_mean,
+        scope=scope)
+
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+
+  layer_variable_getter = _build_variable_getter()
+  with variable_scope.variable_scope(
+      scope,
+      'BatchNorm', [inputs],
+      reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+
+    # Determine whether we can use the core layer class.
+    if (batch_weights is None and
+        updates_collections is ops.GraphKeys.UPDATE_OPS and
+        not zero_debias_moving_mean):
+      # Use the core layer class.
+      axis = 1 if data_format == DATA_FORMAT_NCHW else -1
+      if not param_initializers:
+        param_initializers = {}
+      beta_initializer = param_initializers.get('beta',
+                                                init_ops.zeros_initializer())
+      gamma_initializer = param_initializers.get('gamma',
+                                                 init_ops.ones_initializer())
+      moving_mean_initializer = param_initializers.get(
+          'moving_mean', init_ops.zeros_initializer())
+      moving_variance_initializer = param_initializers.get(
+          'moving_variance', init_ops.ones_initializer())
+      if not param_regularizers:
+        param_regularizers = {}
+      beta_regularizer = param_regularizers.get('beta')
+      gamma_regularizer = param_regularizers.get('gamma')
+      layer = normalization_layers.BatchNormalization(
+          axis=axis,
+          momentum=decay,
+          epsilon=epsilon,
+          center=center,
+          scale=scale,
+          beta_initializer=beta_initializer,
+          gamma_initializer=gamma_initializer,
+          moving_mean_initializer=moving_mean_initializer,
+          moving_variance_initializer=moving_variance_initializer,
+          beta_regularizer=beta_regularizer,
+          gamma_regularizer=gamma_regularizer,
+          trainable=trainable,
+          renorm=renorm,
+          renorm_clipping=renorm_clipping,
+          renorm_momentum=renorm_decay,
+          adjustment=adjustment,
+          name=sc.name,
+          _scope=sc,
+          _reuse=reuse,
+          fused=fused)
+      outputs = layer.apply(inputs, training=is_training)
+
+      # Add variables to collections.
+      _add_variable_to_collections(layer.moving_mean, variables_collections,
+                                   'moving_mean')
+      _add_variable_to_collections(layer.moving_variance, variables_collections,
+                                   'moving_variance')
+      if layer.beta is not None:
+        _add_variable_to_collections(layer.beta, variables_collections, 'beta')
+      if layer.gamma is not None:
+        _add_variable_to_collections(layer.gamma, variables_collections,
+                                     'gamma')
+
+      if activation_fn is not None:
+        outputs = activation_fn(outputs)
+      return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+    # Not supported by layer class: batch_weights argument,
+    # and custom updates_collections. In that case, use the legacy BN
+    # implementation.
+    # Custom updates collections are not supported because the update logic
+    # is different in this case, in particular w.r.t. "forced updates" and
+    # update op reuse.
+    if renorm:
+      raise ValueError('renorm is not supported with batch_weights, '
+                       'updates_collections or zero_debias_moving_mean')
+    inputs_shape = inputs.get_shape()
+    inputs_rank = inputs_shape.ndims
+    if inputs_rank is None:
+      raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+    dtype = inputs.dtype.base_dtype
+    if batch_weights is not None:
+      batch_weights = ops.convert_to_tensor(batch_weights)
+      inputs_shape[0:1].assert_is_compatible_with(batch_weights.get_shape())
+      # Reshape batch weight values so they broadcast across inputs.
+      nshape = [-1] + [1 for _ in range(inputs_rank - 1)]
+      batch_weights = array_ops.reshape(batch_weights, nshape)
+
+    if data_format == DATA_FORMAT_NCHW:
+      moments_axes = [0] + list(range(2, inputs_rank))
+      params_shape = inputs_shape[1:2]
+      # For NCHW format, rather than relying on implicit broadcasting, we
+      # explicitly reshape the params to params_shape_broadcast when computing
+      # the moments and the batch normalization.
+      params_shape_broadcast = list([1, inputs_shape.dims[1].value] +
+                                    [1 for _ in range(2, inputs_rank)])
+    else:
+      moments_axes = list(range(inputs_rank - 1))
+      params_shape = inputs_shape[-1:]
+      params_shape_broadcast = None
+    if not params_shape.is_fully_defined():
+      raise ValueError('Inputs %s has undefined channels dimension %s.' %
+                       (inputs.name, params_shape))
+
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta, gamma = None, None
+    if not param_initializers:
+      param_initializers = {}
+    if center:
+      beta_collections = utils.get_variable_collections(variables_collections,
+                                                        'beta')
+      beta_initializer = param_initializers.get('beta',
+                                                init_ops.zeros_initializer())
+      beta = variables.model_variable(
+          'beta',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=beta_initializer,
+          collections=beta_collections,
+          trainable=trainable)
+    if scale:
+      gamma_collections = utils.get_variable_collections(
+          variables_collections, 'gamma')
+      gamma_initializer = param_initializers.get('gamma',
+                                                 init_ops.ones_initializer())
+      gamma = variables.model_variable(
+          'gamma',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=gamma_initializer,
+          collections=gamma_collections,
+          trainable=trainable)
+
+    # Create moving_mean and moving_variance variables and add them to the
+    # appropriate collections. We disable variable partitioning while creating
+    # them, because assign_moving_average is not yet supported for partitioned
+    # variables (this needs to be handled carefully, as it may break
+    # the checkpoint backward compatibility).
+    with variable_scope.variable_scope(
+        variable_scope.get_variable_scope()) as local_scope:
+      local_scope.set_partitioner(None)
+      moving_mean_collections = utils.get_variable_collections(
+          variables_collections, 'moving_mean')
+      moving_mean_initializer = param_initializers.get(
+          'moving_mean', init_ops.zeros_initializer())
+      moving_mean = variables.model_variable(
+          'moving_mean',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=moving_mean_initializer,
+          trainable=False,
+          collections=moving_mean_collections)
+      moving_variance_collections = utils.get_variable_collections(
+          variables_collections, 'moving_variance')
+      moving_variance_initializer = param_initializers.get(
+          'moving_variance', init_ops.ones_initializer())
+      moving_variance = variables.model_variable(
+          'moving_variance',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=moving_variance_initializer,
+          trainable=False,
+          collections=moving_variance_collections)
+
+    # If `is_training` doesn't have a constant value, because it is a `Tensor`,
+    # a `Variable` or `Placeholder` then is_training_value will be None and
+    # `needs_moments` will be true.
+    is_training_value = utils.constant_value(is_training)
+    need_moments = is_training_value is None or is_training_value
+    if need_moments:
+      # Calculate the moments based on the individual batch.
+      if batch_weights is None:
+        if data_format == DATA_FORMAT_NCHW:
+          mean, variance = nn.moments(inputs, moments_axes, keep_dims=True)
+          mean = array_ops.reshape(mean, [-1])
+          variance = array_ops.reshape(variance, [-1])
+        else:
+          mean, variance = nn.moments(inputs, moments_axes)
+      else:
+        if data_format == DATA_FORMAT_NCHW:
+          mean, variance = nn.weighted_moments(
+              inputs, moments_axes, batch_weights, keepdims=True)
+          mean = array_ops.reshape(mean, [-1])
+          variance = array_ops.reshape(variance, [-1])
+        else:
+          mean, variance = nn.weighted_moments(inputs, moments_axes,
+                                               batch_weights)
+
+      moving_vars_fn = lambda: (moving_mean, moving_variance)
+      if updates_collections is None:
+
+        def _force_updates():
+          """Internal function forces updates moving_vars if is_training."""
+          update_moving_mean = moving_averages.assign_moving_average(
+              moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+          update_moving_variance = moving_averages.assign_moving_average(
+              moving_variance, variance, decay, zero_debias=False)
+          with ops.control_dependencies(
+              [update_moving_mean, update_moving_variance]):
+            return array_ops.identity(mean), array_ops.identity(variance)
+
+        mean, variance = utils.smart_cond(is_training, _force_updates,
+                                          moving_vars_fn)
+      else:
+
+        def _delay_updates():
+          """Internal function that delay updates moving_vars if is_training."""
+          update_moving_mean = moving_averages.assign_moving_average(
+              moving_mean, mean, decay, zero_debias=zero_debias_moving_mean)
+          update_moving_variance = moving_averages.assign_moving_average(
+              moving_variance, variance, decay, zero_debias=False)
+          return update_moving_mean, update_moving_variance
+
+        update_mean, update_variance = utils.smart_cond(is_training,
+                                                        _delay_updates,
+                                                        moving_vars_fn)
+        ops.add_to_collections(updates_collections, update_mean)
+        ops.add_to_collections(updates_collections, update_variance)
+        # Use computed moments during training and moving_vars otherwise.
+        vars_fn = lambda: (mean, variance)
+        mean, variance = utils.smart_cond(is_training, vars_fn, moving_vars_fn)
+    else:
+      mean, variance = moving_mean, moving_variance
+    if data_format == DATA_FORMAT_NCHW:
+      mean = array_ops.reshape(mean, params_shape_broadcast)
+      variance = array_ops.reshape(variance, params_shape_broadcast)
+      if beta is not None:
+        beta = array_ops.reshape(beta, params_shape_broadcast)
+      if gamma is not None:
+        gamma = array_ops.reshape(gamma, params_shape_broadcast)
+
+    # Compute batch_normalization.
+    outputs = nn.batch_normalization(inputs, mean, variance, beta, gamma,
+                                     epsilon)
+    outputs.set_shape(inputs_shape)
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def bias_add(inputs,
+             activation_fn=None,
+             initializer=init_ops.zeros_initializer(),
+             regularizer=None,
+             reuse=None,
+             variables_collections=None,
+             outputs_collections=None,
+             trainable=True,
+             data_format=DATA_FORMAT_NHWC,
+             scope=None):
+  """Adds a bias to the inputs.
+
+  Can be used as a normalizer function for conv2d and fully_connected.
+
+  Args:
+    inputs: A tensor of with at least rank 2 and value for the last dimension,
+      e.g. `[batch_size, depth]`, `[None, None, None, depth]`.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    initializer: An initializer for the bias, defaults to 0.
+    regularizer: A regularizer like the result of `l1_regularizer` or
+      `l2_regularizer`.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    data_format: A string. 'NHWC' and 'NCHW' are supported.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A tensor representing the result of adding biases to the inputs.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If `data_format` is `NCHW` and rank of `inputs` is not 4.
+    ValueError: If the rank of `inputs` is undefined.
+    ValueError: If rank or `C` dimension of `inputs` is undefined.
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  with variable_scope.variable_scope(
+      scope, 'BiasAdd', [inputs], reuse=reuse) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    dtype = inputs.dtype.base_dtype
+    inputs_shape = inputs.get_shape()
+    inputs_rank = inputs_shape.ndims
+    if inputs_rank is None:
+      raise ValueError('Dims of shape must be known but is None')
+    elif inputs_rank != 4 and data_format == DATA_FORMAT_NCHW:
+      raise ValueError('Data format NCHW only supports 4D Tensor')
+    axis = 1 if data_format == DATA_FORMAT_NCHW else -1
+    num_features = inputs_shape.dims[axis].value
+    if num_features is None:
+      raise ValueError('`C` dimension must be known but is None')
+    biases_collections = utils.get_variable_collections(variables_collections,
+                                                        'biases')
+    biases = variables.model_variable(
+        'biases',
+        shape=[
+            num_features,
+        ],
+        dtype=dtype,
+        initializer=initializer,
+        regularizer=regularizer,
+        collections=biases_collections,
+        trainable=trainable)
+    outputs = nn.bias_add(inputs, biases, data_format=data_format)
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+# TODO(jbms): change `rate` parameter to `dilation_rate` for consistency with
+# underlying op.
+@add_arg_scope
+def convolution(inputs,
+                num_outputs,
+                kernel_size,
+                stride=1,
+                padding='SAME',
+                data_format=None,
+                rate=1,
+                activation_fn=nn.relu,
+                normalizer_fn=None,
+                normalizer_params=None,
+                weights_initializer=initializers.xavier_initializer(),
+                weights_regularizer=None,
+                biases_initializer=init_ops.zeros_initializer(),
+                biases_regularizer=None,
+                reuse=None,
+                variables_collections=None,
+                outputs_collections=None,
+                trainable=True,
+                scope=None,
+                conv_dims=None):
+  """Adds an N-D convolution followed by an optional batch_norm layer.
+
+  It is required that 1 <= N <= 3.
+
+  `convolution` creates a variable called `weights`, representing the
+  convolutional kernel, that is convolved (actually cross-correlated) with the
+  `inputs` to produce a `Tensor` of activations. If a `normalizer_fn` is
+  provided (such as `batch_norm`), it is then applied. Otherwise, if
+  `normalizer_fn` is None and a `biases_initializer` is provided then a `biases`
+  variable would be created and added the activations. Finally, if
+  `activation_fn` is not `None`, it is applied to the activations as well.
+
+  Performs atrous convolution with input stride/dilation rate equal to `rate`
+  if a value > 1 for any dimension of `rate` is specified.  In this case
+  `stride` values != 1 are not supported.
+
+  Args:
+    inputs: A Tensor of rank N+2 of shape `[batch_size] + input_spatial_shape +
+      [in_channels]` if data_format does not start with "NC" (default), or
+      `[batch_size, in_channels] + input_spatial_shape` if data_format starts
+      with "NC".
+    num_outputs: Integer, the number of output filters.
+    kernel_size: A sequence of N positive integers specifying the spatial
+      dimensions of the filters.  Can be a single integer to specify the same
+      value for all spatial dimensions.
+    stride: A sequence of N positive integers specifying the stride at which to
+      compute output.  Can be a single integer to specify the same value for all
+      spatial dimensions.  Specifying any `stride` value != 1 is incompatible
+      with specifying any `rate` value != 1.
+    padding: One of `"VALID"` or `"SAME"`.
+    data_format: A string or None.  Specifies whether the channel dimension of
+      the `input` and output is the last dimension (default, or if `data_format`
+      does not start with "NC"), or the second dimension (if `data_format`
+      starts with "NC").  For N=1, the valid values are "NWC" (default) and
+      "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW". For
+      N=3, the valid values are "NDHWC" (default) and "NCDHW".
+    rate: A sequence of N positive integers specifying the dilation rate to use
+      for atrous convolution.  Can be a single integer to specify the same value
+      for all spatial dimensions.  Specifying any `rate` value != 1 is
+      incompatible with specifying any `stride` value != 1.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    scope: Optional scope for `variable_scope`.
+    conv_dims: Optional convolution dimensionality, when set it would use the
+      corresponding convolution (e.g. 2 for Conv 2D, 3 for Conv 3D, ..). When
+      leaved to None it would select the convolution dimensionality based on the
+      input rank (i.e. Conv ND, with N = input_rank - 2).
+
+  Returns:
+    A tensor representing the output of the operation.
+
+  Raises:
+    ValueError: If `data_format` is invalid.
+    ValueError: Both 'rate' and `stride` are not uniformly 1.
+  """
+  if data_format not in [None, 'NWC', 'NCW', 'NHWC', 'NCHW', 'NDHWC', 'NCDHW']:
+    raise ValueError('Invalid data_format: %r' % (data_format,))
+
+  layer_variable_getter = _build_variable_getter({
+      'bias': 'biases',
+      'kernel': 'weights'
+  })
+
+  with variable_scope.variable_scope(
+      scope, 'Conv', [inputs], reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    input_rank = inputs.get_shape().ndims
+
+    if conv_dims is not None and conv_dims + 2 != input_rank:
+      raise ValueError('Convolution expects input with rank %d, got %d' %
+                       (conv_dims + 2, input_rank))
+    if input_rank == 3:
+      layer_class = convolutional_layers.Convolution1D
+    elif input_rank == 4:
+      layer_class = convolutional_layers.Convolution2D
+    elif input_rank == 5:
+      layer_class = convolutional_layers.Convolution3D
+    else:
+      raise ValueError('Convolution not supported for input with rank',
+                       input_rank)
+
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = layer_class(
+        filters=num_outputs,
+        kernel_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        dilation_rate=rate,
+        activation=None,
+        use_bias=not normalizer_fn and biases_initializer,
+        kernel_initializer=weights_initializer,
+        bias_initializer=biases_initializer,
+        kernel_regularizer=weights_regularizer,
+        bias_regularizer=biases_regularizer,
+        activity_regularizer=None,
+        trainable=trainable,
+        name=sc.name,
+        dtype=inputs.dtype.base_dtype,
+        _scope=sc,
+        _reuse=reuse)
+    outputs = layer.apply(inputs)
+
+    # Add variables to collections.
+    _add_variable_to_collections(layer.kernel, variables_collections, 'weights')
+    if layer.use_bias:
+      _add_variable_to_collections(layer.bias, variables_collections, 'biases')
+
+    if normalizer_fn is not None:
+      normalizer_params = normalizer_params or {}
+      outputs = normalizer_fn(outputs, **normalizer_params)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution1d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+  return convolution(
+      inputs,
+      num_outputs,
+      kernel_size,
+      stride,
+      padding,
+      data_format,
+      rate,
+      activation_fn,
+      normalizer_fn,
+      normalizer_params,
+      weights_initializer,
+      weights_regularizer,
+      biases_initializer,
+      biases_regularizer,
+      reuse,
+      variables_collections,
+      outputs_collections,
+      trainable,
+      scope,
+      conv_dims=1)
+
+
+convolution1d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution2d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+  return convolution(
+      inputs,
+      num_outputs,
+      kernel_size,
+      stride,
+      padding,
+      data_format,
+      rate,
+      activation_fn,
+      normalizer_fn,
+      normalizer_params,
+      weights_initializer,
+      weights_regularizer,
+      biases_initializer,
+      biases_regularizer,
+      reuse,
+      variables_collections,
+      outputs_collections,
+      trainable,
+      scope,
+      conv_dims=2)
+
+
+convolution2d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution3d(inputs,
+                  num_outputs,
+                  kernel_size,
+                  stride=1,
+                  padding='SAME',
+                  data_format=None,
+                  rate=1,
+                  activation_fn=nn.relu,
+                  normalizer_fn=None,
+                  normalizer_params=None,
+                  weights_initializer=initializers.xavier_initializer(),
+                  weights_regularizer=None,
+                  biases_initializer=init_ops.zeros_initializer(),
+                  biases_regularizer=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  scope=None):
+  return convolution(
+      inputs,
+      num_outputs,
+      kernel_size,
+      stride,
+      padding,
+      data_format,
+      rate,
+      activation_fn,
+      normalizer_fn,
+      normalizer_params,
+      weights_initializer,
+      weights_regularizer,
+      biases_initializer,
+      biases_regularizer,
+      reuse,
+      variables_collections,
+      outputs_collections,
+      trainable,
+      scope,
+      conv_dims=3)
+
+
+convolution3d.__doc__ = convolution.__doc__
+
+
+@add_arg_scope
+def convolution2d_in_plane(
+    inputs,
+    kernel_size,
+    stride=1,
+    padding='SAME',
+    activation_fn=nn.relu,
+    normalizer_fn=None,
+    normalizer_params=None,
+    weights_initializer=initializers.xavier_initializer(),
+    weights_regularizer=None,
+    biases_initializer=init_ops.zeros_initializer(),
+    biases_regularizer=None,
+    reuse=None,
+    variables_collections=None,
+    outputs_collections=None,
+    trainable=True,
+    scope=None):
+  """Performs the same in-plane convolution to each channel independently.
+
+  This is useful for performing various simple channel-independent convolution
+  operations such as image gradients:
+
+    image = tf.constant(..., shape=(16, 240, 320, 3))
+    vert_gradients = layers.conv2d_in_plane(image,
+                                            kernel=[1, -1],
+                                            kernel_size=[2, 1])
+    horz_gradients = layers.conv2d_in_plane(image,
+                                            kernel=[1, -1],
+                                            kernel_size=[1, 2])
+
+  Args:
+    inputs: A 4-D tensor with dimensions [batch_size, height, width, channels].
+    kernel_size: A list of length 2 holding the [kernel_height, kernel_width] of
+      of the pooling. Can be an int if both values are the same.
+    stride: A list of length 2 `[stride_height, stride_width]`. Can be an int if
+      both strides are the same. Note that presently both strides must have the
+      same value.
+    padding: The padding type to use, either 'SAME' or 'VALID'.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    scope: Optional scope for `variable_scope`.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+  """
+  with variable_scope.variable_scope(
+      scope, 'ConvInPlane', [inputs], reuse=reuse) as sc:
+    dtype = inputs.dtype.base_dtype
+    kernel_h, kernel_w = utils.two_element_tuple(kernel_size)
+    stride_h, stride_w = utils.two_element_tuple(stride)
+    num_filters_in = utils.last_dimension(inputs.get_shape(), min_rank=4)
+    weights_shape = [kernel_h, kernel_w, 1, 1]
+    weights_collections = utils.get_variable_collections(
+        variables_collections, 'weights')
+    weights = variables.model_variable(
+        'weights',
+        shape=weights_shape,
+        dtype=dtype,
+        initializer=weights_initializer,
+        regularizer=weights_regularizer,
+        collections=weights_collections,
+        trainable=trainable)
+    depthwise_weights = array_ops.tile(weights, [1, 1, num_filters_in, 1])
+    outputs = nn.depthwise_conv2d(inputs, depthwise_weights,
+                                  [1, stride_h, stride_w, 1], padding)
+    if normalizer_fn is not None:
+      normalizer_params = normalizer_params or {}
+      outputs = normalizer_fn(outputs, **normalizer_params)
+    else:
+      if biases_initializer is not None:
+        biases_collections = utils.get_variable_collections(
+            variables_collections, 'biases')
+        biases = variables.model_variable(
+            'biases',
+            shape=[
+                num_filters_in,
+            ],
+            dtype=dtype,
+            initializer=biases_initializer,
+            regularizer=biases_regularizer,
+            collections=biases_collections,
+            trainable=trainable)
+        outputs = nn.bias_add(outputs, biases)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution2d_transpose(
+    inputs,
+    num_outputs,
+    kernel_size,
+    stride=1,
+    padding='SAME',
+    data_format=DATA_FORMAT_NHWC,
+    activation_fn=nn.relu,
+    normalizer_fn=None,
+    normalizer_params=None,
+    weights_initializer=initializers.xavier_initializer(),
+    weights_regularizer=None,
+    biases_initializer=init_ops.zeros_initializer(),
+    biases_regularizer=None,
+    reuse=None,
+    variables_collections=None,
+    outputs_collections=None,
+    trainable=True,
+    scope=None):
+  """Adds a convolution2d_transpose with an optional batch normalization layer.
+
+  The function creates a variable called `weights`, representing the
+  kernel, that is convolved with the input. If `normalizer_fn` is `None`, a
+  second variable called 'biases' is added to the result of the operation.
+
+  Args:
+    inputs: A 4-D `Tensor` of type `float` and shape `[batch, height, width,
+      in_channels]` for `NHWC` data format or `[batch, in_channels, height,
+      width]` for `NCHW` data format.
+    num_outputs: Integer, the number of output filters.
+    kernel_size: A list of length 2 holding the [kernel_height, kernel_width] of
+      of the filters. Can be an int if both values are the same.
+    stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+      both strides are the same.  Note that presently both strides must have the
+      same value.
+    padding: One of 'VALID' or 'SAME'.
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: Whether or not the variables should be trainable or not.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A tensor representing the output of the operation.
+
+  Raises:
+    ValueError: If 'kernel_size' is not a list of length 2.
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If `C` dimension of `inputs` is None.
+  """
+  layer_variable_getter = _build_variable_getter({
+      'bias': 'biases',
+      'kernel': 'weights'
+  })
+
+  with variable_scope.variable_scope(
+      scope,
+      'Conv2d_transpose', [inputs],
+      reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+      raise ValueError('data_format has to be either NCHW or NHWC.')
+
+    inputs = ops.convert_to_tensor(inputs)
+
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = convolutional_layers.Convolution2DTranspose(
+        filters=num_outputs,
+        kernel_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        activation=None,
+        use_bias=not normalizer_fn and biases_initializer,
+        kernel_initializer=weights_initializer,
+        bias_initializer=biases_initializer,
+        kernel_regularizer=weights_regularizer,
+        bias_regularizer=biases_regularizer,
+        activity_regularizer=None,
+        trainable=trainable,
+        name=sc.name,
+        dtype=inputs.dtype.base_dtype,
+        _scope=sc,
+        _reuse=reuse)
+    outputs = layer.apply(inputs)
+
+    # Add variables to collections.
+    _add_variable_to_collections(layer.kernel, variables_collections, 'weights')
+    if layer.bias is not None:
+      _add_variable_to_collections(layer.bias, variables_collections, 'biases')
+
+    if normalizer_fn is not None:
+      normalizer_params = normalizer_params or {}
+      outputs = normalizer_fn(outputs, **normalizer_params)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def convolution3d_transpose(
+    inputs,
+    num_outputs,
+    kernel_size,
+    stride=1,
+    padding='SAME',
+    data_format=DATA_FORMAT_NDHWC,
+    activation_fn=nn.relu,
+    normalizer_fn=None,
+    normalizer_params=None,
+    weights_initializer=initializers.xavier_initializer(),
+    weights_regularizer=None,
+    biases_initializer=init_ops.zeros_initializer(),
+    biases_regularizer=None,
+    reuse=None,
+    variables_collections=None,
+    outputs_collections=None,
+    trainable=True,
+    scope=None):
+  """Adds a convolution3d_transpose with an optional batch normalization layer.
+
+  The function creates a variable called `weights`, representing the
+  kernel, that is convolved with the input. If `batch_norm_params` is `None`, a
+  second variable called 'biases' is added to the result of the operation.
+  Args:
+    inputs: A 5-D `Tensor` of type `float` and shape `[batch, depth, height,
+      width, in_channels]` for `NDHWC` data format or `[batch, in_channels,
+      depth, height, width]` for `NCDHW` data format.
+    num_outputs: Integer, the number of output filters.
+    kernel_size: A list of length 3 holding the [kernel_depth, kernel_height,
+      kernel_width] of the filters. Can be an int if both values are the same.
+    stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+      be an int if both strides are the same.  Note that presently both strides
+      must have the same value.
+    padding: One of 'VALID' or 'SAME'.
+    data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: Whether or not the variables should be trainable or not.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A tensor representing the output of the operation.
+  Raises:
+    ValueError: If 'kernel_size' is not a list of length 3.
+    ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+    ValueError: If `C` dimension of `inputs` is None.
+  """
+  layer_variable_getter = _build_variable_getter({
+      'bias': 'biases',
+      'kernel': 'weights'
+  })
+
+  with variable_scope.variable_scope(
+      scope,
+      'Conv3d_transpose', [inputs],
+      reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+      raise ValueError('data_format has to be either NCDHW or NDHWC.')
+
+    inputs = ops.convert_to_tensor(inputs)
+
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = convolutional_layers.Convolution3DTranspose(
+        filters=num_outputs,
+        kernel_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        activation=None,
+        use_bias=not normalizer_fn and biases_initializer,
+        kernel_initializer=weights_initializer,
+        bias_initializer=biases_initializer,
+        kernel_regularizer=weights_regularizer,
+        bias_regularizer=biases_regularizer,
+        activity_regularizer=None,
+        trainable=trainable,
+        name=sc.name,
+        dtype=inputs.dtype.base_dtype,
+        _scope=sc,
+        _reuse=reuse)
+    outputs = layer.apply(inputs)
+
+    # Add variables to collections.
+    _add_variable_to_collections(layer.kernel, variables_collections, 'weights')
+    if layer.bias is not None:
+      _add_variable_to_collections(layer.bias, variables_collections, 'biases')
+
+    if normalizer_fn is not None:
+      normalizer_params = normalizer_params or {}
+      outputs = normalizer_fn(outputs, **normalizer_params)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def dense_to_sparse(tensor, eos_token=0, outputs_collections=None, scope=None):
+  """Converts a dense tensor into a sparse tensor.
+
+  An example use would be to convert dense labels to sparse ones
+  so that they can be fed to the ctc_loss.
+
+  Args:
+     tensor: An `int` `Tensor` to be converted to a `Sparse`.
+     eos_token: An integer. It is part of the target label that signifies the
+       end of a sentence.
+     outputs_collections: Collection to add the outputs.
+     scope: Optional scope for name_scope.
+  """
+  with variable_scope.variable_scope(scope, 'dense_to_sparse', [tensor]) as sc:
+    tensor = ops.convert_to_tensor(tensor)
+    indices = array_ops.where(
+        math_ops.not_equal(tensor, constant_op.constant(eos_token,
+                                                        tensor.dtype)))
+    values = array_ops.gather_nd(tensor, indices)
+    shape = array_ops.shape(tensor, out_type=dtypes.int64)
+    outputs = sparse_tensor.SparseTensor(indices, values, shape)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def dropout(inputs,
+            keep_prob=0.5,
+            noise_shape=None,
+            is_training=True,
+            outputs_collections=None,
+            scope=None,
+            seed=None):
+  """Returns a dropout op applied to the input.
+
+  With probability `keep_prob`, outputs the input element scaled up by
+  `1 / keep_prob`, otherwise outputs `0`.  The scaling is so that the expected
+  sum is unchanged.
+
+  Args:
+    inputs: The tensor to pass to the nn.dropout op.
+    keep_prob: A scalar `Tensor` with the same type as x. The probability that
+      each element is kept.
+    noise_shape: A 1-D `Tensor` of type `int32`, representing the shape for
+      randomly generated keep/drop flags.
+    is_training: A bool `Tensor` indicating whether or not the model is in
+      training mode. If so, dropout is applied and values scaled. Otherwise,
+      inputs is returned.
+    outputs_collections: Collection to add the outputs.
+    scope: Optional scope for name_scope.
+    seed: A Python integer. Used to create random seeds. See
+      `tf.compat.v1.set_random_seed` for behavior.
+
+  Returns:
+    A tensor representing the output of the operation.
+  """
+  with variable_scope.variable_scope(
+      scope, 'Dropout', [inputs], custom_getter=_model_variable_getter) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    layer = core_layers.Dropout(
+        rate=1 - keep_prob,
+        noise_shape=noise_shape,
+        seed=seed,
+        name=sc.name,
+        _scope=sc)
+    outputs = layer.apply(inputs, training=is_training)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def flatten(inputs, outputs_collections=None, scope=None):
+  """Flattens the input while maintaining the batch_size.
+
+    Assumes that the first dimension represents the batch.
+
+  Args:
+    inputs: A tensor of size [batch_size, ...].
+    outputs_collections: Collection to add the outputs.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A flattened tensor with shape [batch_size, k].
+  Raises:
+    ValueError: If inputs rank is unknown or less than 2.
+  """
+  with ops.name_scope(scope, 'Flatten', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    outputs = core_layers.flatten(inputs)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _sparse_inner_flatten(inputs, new_rank):
+  """Helper function for `inner_flatten`."""
+  inputs_rank = inputs.dense_shape.get_shape().as_list()[0]
+  if inputs_rank < new_rank:
+    raise ValueError(
+        'Inputs has rank less than new_rank. {} must have rank at least'
+        ' {}. Received rank {}, shape {}'.format(inputs, new_rank, inputs_rank,
+                                                 inputs.get_shape()))
+
+  outer_dimensions = inputs.dense_shape[:new_rank - 1]
+  inner_dimensions = inputs.dense_shape[new_rank - 1:]
+  new_shape = array_ops.concat(
+      (outer_dimensions, [math_ops.reduce_prod(inner_dimensions)]), 0)
+  flattened = sparse_ops.sparse_reshape(inputs, new_shape)
+  return flattened
+
+
+def _dense_inner_flatten(inputs, new_rank):
+  """Helper function for `inner_flatten`."""
+  rank_assertion = check_ops.assert_rank_at_least(
+      inputs, new_rank, message='inputs has rank less than new_rank')
+  with ops.control_dependencies([rank_assertion]):
+    outer_dimensions = array_ops.strided_slice(
+        array_ops.shape(inputs), [0], [new_rank - 1])
+    new_shape = array_ops.concat((outer_dimensions, [-1]), 0)
+    reshaped = array_ops.reshape(inputs, new_shape)
+
+  # if `new_rank` is an integer, try to calculate new shape.
+  if isinstance(new_rank, six.integer_types):
+    static_shape = inputs.get_shape()
+    if static_shape is not None and static_shape.dims is not None:
+      static_shape = static_shape.as_list()
+      static_outer_dims = static_shape[:new_rank - 1]
+      static_inner_dims = static_shape[new_rank - 1:]
+      flattened_dimension = 1
+      for inner_dim in static_inner_dims:
+        if inner_dim is None:
+          flattened_dimension = None
+          break
+        flattened_dimension *= inner_dim
+      reshaped.set_shape(static_outer_dims + [flattened_dimension])
+  return reshaped
+
+
+@add_arg_scope
+def _inner_flatten(inputs, new_rank, output_collections=None, scope=None):
+  """Flattens inner dimensions of `inputs`, returns a Tensor with `new_rank`.
+
+  For example:
+  '''
+      x = tf.random.uniform(shape=[1, 2, 3, 4, 5, 6])
+      y = _inner_flatten(x, 4)
+      assert y.get_shape().as_list() == [1, 2, 3, (4 * 5 * 6)]
+  '''
+  This layer will fail at run time if `new_rank` is greater than the current
+  rank of `inputs`.
+
+  Args:
+    inputs: A `Tensor` or `SparseTensor`.
+    new_rank: The desired rank of the returned `Tensor` or `SparseTensor`.
+    output_collections: Collection to which the outputs will be added.
+    scope: Optional scope for `name_scope`.
+
+  Returns:
+    A `Tensor` or `SparseTensor` containing the same values as `inputs`, but
+    with innermost dimensions flattened to obtain rank `new_rank`.
+
+  Raises:
+    TypeError: `inputs` is not a `Tensor` or `SparseTensor`.
+  """
+  with ops.name_scope(scope, 'InnerFlatten', [inputs, new_rank]) as sc:
+    if isinstance(inputs, sparse_tensor.SparseTensor):
+      flattened = _sparse_inner_flatten(inputs, new_rank)
+    else:
+      inputs = ops.convert_to_tensor(inputs)
+      flattened = _dense_inner_flatten(inputs, new_rank)
+  return utils.collect_named_outputs(output_collections, sc, flattened)
+
+
+def _model_variable_getter(
+    getter,
+    name,
+    shape=None,
+    dtype=None,
+    initializer=None,
+    regularizer=None,
+    trainable=True,
+    collections=None,
+    caching_device=None,
+    partitioner=None,
+    rename=None,
+    use_resource=None,
+    synchronization=tf_variables.VariableSynchronization.AUTO,
+    aggregation=tf_variables.VariableAggregation.NONE,
+    **_):
+  """Getter that uses model_variable for compatibility with core layers."""
+  short_name = name.split('/')[-1]
+  if rename and short_name in rename:
+    name_components = name.split('/')
+    name_components[-1] = rename[short_name]
+    name = '/'.join(name_components)
+  return variables.model_variable(
+      name,
+      shape=shape,
+      dtype=dtype,
+      initializer=initializer,
+      regularizer=regularizer,
+      collections=collections,
+      trainable=trainable,
+      caching_device=caching_device,
+      partitioner=partitioner,
+      custom_getter=getter,
+      use_resource=use_resource,
+      synchronization=synchronization,
+      aggregation=aggregation)
+
+
+def _build_variable_getter(rename=None):
+  """Build a model variable getter that respects scope getter and renames."""
+
+  # VariableScope will nest the getters
+  def layer_variable_getter(getter, *args, **kwargs):
+    kwargs['rename'] = rename
+    return _model_variable_getter(getter, *args, **kwargs)
+
+  return layer_variable_getter
+
+
+def _add_variable_to_collections(variable, collections_set, collections_name):
+  """Adds variable (or all its parts) to all collections with that name."""
+  collections = utils.get_variable_collections(collections_set,
+                                               collections_name) or []
+  variables_list = [variable]
+  if isinstance(variable, tf_variables.PartitionedVariable):
+    variables_list = [v for v in variable]
+  for collection in collections:
+    for var in variables_list:
+      if var not in ops.get_collection(collection):
+        ops.add_to_collection(collection, var)
+
+
+@add_arg_scope
+def fully_connected(inputs,
+                    num_outputs,
+                    activation_fn=nn.relu,
+                    normalizer_fn=None,
+                    normalizer_params=None,
+                    weights_initializer=initializers.xavier_initializer(),
+                    weights_regularizer=None,
+                    biases_initializer=init_ops.zeros_initializer(),
+                    biases_regularizer=None,
+                    reuse=None,
+                    variables_collections=None,
+                    outputs_collections=None,
+                    trainable=True,
+                    scope=None):
+  """Adds a fully connected layer.
+
+  `fully_connected` creates a variable called `weights`, representing a fully
+  connected weight matrix, which is multiplied by the `inputs` to produce a
+  `Tensor` of hidden units. If a `normalizer_fn` is provided (such as
+  `batch_norm`), it is then applied. Otherwise, if `normalizer_fn` is
+  None and a `biases_initializer` is provided then a `biases` variable would be
+  created and added the hidden units. Finally, if `activation_fn` is not `None`,
+  it is applied to the hidden units as well.
+
+  Note: that if `inputs` have a rank greater than 2, then `inputs` is flattened
+  prior to the initial matrix multiply by `weights`.
+
+  Args:
+    inputs: A tensor of at least rank 2 and static value for the last dimension;
+      i.e. `[batch_size, depth]`, `[None, None, None, channels]`.
+    num_outputs: Integer or long, the number of output units in the layer.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the weights.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collections per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    scope: Optional scope for variable_scope.
+
+  Returns:
+     The tensor variable representing the result of the series of operations.
+
+  Raises:
+    ValueError: If x has rank less than 2 or if its last dimension is not set.
+  """
+  if not isinstance(num_outputs, six.integer_types):
+    raise ValueError('num_outputs type should be one of %s, got %s.' %
+                     (list(six.integer_types), type(num_outputs)))
+
+  layer_variable_getter = _build_variable_getter({
+      'bias': 'biases',
+      'kernel': 'weights'
+  })
+
+  with variable_scope.variable_scope(
+      scope,
+      'fully_connected', [inputs],
+      reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    layer = core_layers.Dense(
+        units=num_outputs,
+        activation=None,
+        use_bias=not normalizer_fn and biases_initializer,
+        kernel_initializer=weights_initializer,
+        bias_initializer=biases_initializer,
+        kernel_regularizer=weights_regularizer,
+        bias_regularizer=biases_regularizer,
+        activity_regularizer=None,
+        trainable=trainable,
+        name=sc.name,
+        dtype=inputs.dtype.base_dtype,
+        _scope=sc,
+        _reuse=reuse)
+    outputs = layer.apply(inputs)
+
+    # Add variables to collections.
+    _add_variable_to_collections(layer.kernel, variables_collections, 'weights')
+    if layer.bias is not None:
+      _add_variable_to_collections(layer.bias, variables_collections, 'biases')
+
+    # Apply normalizer function / layer.
+    if normalizer_fn is not None:
+      if not normalizer_params:
+        normalizer_params = {}
+      outputs = normalizer_fn(outputs, **normalizer_params)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+class GDN(base.Layer):
+  """Generalized divisive normalization layer.
+
+  Based on the papers:
+
+    "Density Modeling of Images using a Generalized Normalization
+    Transformation"
+
+    Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+
+    https://arxiv.org/abs/1511.06281
+
+    "End-to-end Optimized Image Compression"
+
+    Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+
+    https://arxiv.org/abs/1611.01704
+
+  Implements an activation function that is essentially a multivariate
+  generalization of a particular sigmoid-type function:
+
+  ```
+  y[i] = x[i] / sqrt(beta[i] + sum_j(gamma[j, i] * x[j]))
+  ```
+
+  where `i` and `j` run over channels. This implementation never sums across
+  spatial dimensions. It is similar to local response normalization, but much
+  more flexible, as `beta` and `gamma` are trainable parameters.
+
+  Arguments:
+    inverse: If `False` (default), compute GDN response. If `True`, compute IGDN
+      response (one step of fixed point iteration to invert GDN; the division is
+      replaced by multiplication).
+    beta_min: Lower bound for beta, to prevent numerical error from causing
+      square root of zero or negative values.
+    gamma_init: The gamma matrix will be initialized as the identity matrix
+      multiplied with this value. If set to zero, the layer is effectively
+      initialized to the identity operation, since beta is initialized as one. A
+      good default setting is somewhere between 0 and 0.5.
+    reparam_offset: Offset added to the reparameterization of beta and gamma.
+      The reparameterization of beta and gamma as their square roots lets the
+      training slow down when their values are close to zero, which is desirable
+      as small values in the denominator can lead to a situation where gradient
+      noise on beta/gamma leads to extreme amounts of noise in the GDN
+      activations. However, without the offset, we would get zero gradients if
+      any elements of beta or gamma were exactly zero, and thus the training
+      could get stuck. To prevent this, we add this small constant. The default
+      value was empirically determined as a good starting point. Making it
+      bigger potentially leads to more gradient noise on the activations, making
+      it too small may lead to numerical precision issues.
+    data_format: Format of input tensor. Currently supports `'channels_first'`
+      and `'channels_last'`.
+    activity_regularizer: Regularizer function for the output.
+    trainable: Boolean, if `True`, also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    name: String, the name of the layer. Layers with the same name will share
+      weights, but to avoid mistakes we require `reuse=True` in such cases.
+  Properties:
+    inverse: Boolean, whether GDN is computed (`True`) or IGDN (`False`).
+    data_format: Format of input tensor. Currently supports `'channels_first'`
+      and `'channels_last'`.
+    beta: The beta parameter as defined above (1D `Tensor`).
+    gamma: The gamma parameter as defined above (2D `Tensor`).
+  """
+
+  def __init__(self,
+               inverse=False,
+               beta_min=1e-6,
+               gamma_init=.1,
+               reparam_offset=2**-18,
+               data_format='channels_last',
+               activity_regularizer=None,
+               trainable=True,
+               name=None,
+               **kwargs):
+    super(GDN, self).__init__(
+        trainable=trainable,
+        name=name,
+        activity_regularizer=activity_regularizer,
+        **kwargs)
+    self.inverse = inverse
+    self._beta_min = beta_min
+    self._gamma_init = gamma_init
+    self._reparam_offset = reparam_offset
+    self.data_format = data_format
+    self._channel_axis()  # trigger ValueError early
+    self.input_spec = input_spec.InputSpec(min_ndim=3, max_ndim=5)
+
+  def _channel_axis(self):
+    try:
+      return {'channels_first': 1, 'channels_last': -1}[self.data_format]
+    except KeyError:
+      raise ValueError('Unsupported `data_format` for GDN layer: {}.'.format(
+          self.data_format))
+
+  @staticmethod
+  def _lower_bound(inputs, bound, name=None):
+    """Same as tf.maximum, but with helpful gradient for inputs < bound.
+
+    The gradient is overwritten so that it is passed through if the input is not
+    hitting the bound. If it is, only gradients that push `inputs` higher than
+    the bound are passed through. No gradients are passed through to the bound.
+
+    Args:
+      inputs: input tensor
+      bound: lower bound for the input tensor
+      name: name for this op
+
+    Returns:
+      tf.maximum(inputs, bound)
+    """
+    with ops.name_scope(name, 'GDNLowerBound', [inputs, bound]) as scope:
+      inputs = ops.convert_to_tensor(inputs, name='inputs')
+      bound = ops.convert_to_tensor(bound, name='bound')
+      with ops.get_default_graph().gradient_override_map(
+          {'Maximum': 'GDNLowerBound'}):
+        return math_ops.maximum(inputs, bound, name=scope)
+
+  @staticmethod
+  def _lower_bound_grad(op, grad):
+    """Gradient for `_lower_bound`.
+
+    Args:
+      op: the tensorflow op for which to calculate a gradient
+      grad: gradient with respect to the output of the op
+
+    Returns:
+      gradients with respect to the inputs of the op
+    """
+    inputs = op.inputs[0]
+    bound = op.inputs[1]
+    pass_through_if = math_ops.logical_or(inputs >= bound, grad < 0)
+    return [math_ops.cast(pass_through_if, grad.dtype) * grad, None]
+
+  def build(self, input_shape):
+    channel_axis = self._channel_axis()
+    input_shape = tensor_shape.TensorShape(input_shape)
+    num_channels = input_shape.dims[channel_axis].value
+    if num_channels is None:
+      raise ValueError('The channel dimension of the inputs to `GDN` '
+                       'must be defined.')
+    self._input_rank = input_shape.ndims
+    self.input_spec = input_spec.InputSpec(
+        ndim=input_shape.ndims, axes={channel_axis: num_channels})
+
+    pedestal = array_ops.constant(self._reparam_offset**2, dtype=self.dtype)
+    beta_bound = array_ops.constant(
+        (self._beta_min + self._reparam_offset**2)**.5, dtype=self.dtype)
+    gamma_bound = array_ops.constant(self._reparam_offset, dtype=self.dtype)
+
+    def beta_initializer(shape, dtype=None, partition_info=None):
+      del partition_info  # unused
+      pedestal = array_ops.constant(self._reparam_offset**2, dtype=self.dtype)
+      return math_ops.sqrt(array_ops.ones(shape, dtype=dtype) + pedestal)
+
+    def gamma_initializer(shape, dtype=None, partition_info=None):
+      del partition_info  # unused
+      assert len(shape) == 2
+      assert shape[0] == shape[1]
+      eye = linalg_ops.eye(shape[0], dtype=dtype)
+      pedestal = array_ops.constant(self._reparam_offset**2, dtype=self.dtype)
+      return math_ops.sqrt(self._gamma_init * eye + pedestal)
+
+    beta = self.add_variable(
+        'reparam_beta',
+        shape=[num_channels],
+        initializer=beta_initializer,
+        dtype=self.dtype,
+        trainable=True)
+    beta = self._lower_bound(beta, beta_bound)
+    self.beta = math_ops.square(beta) - pedestal
+
+    gamma = self.add_variable(
+        'reparam_gamma',
+        shape=[num_channels, num_channels],
+        initializer=gamma_initializer,
+        dtype=self.dtype,
+        trainable=True)
+    gamma = self._lower_bound(gamma, gamma_bound)
+    self.gamma = math_ops.square(gamma) - pedestal
+
+    self.built = True
+
+  def call(self, inputs):
+    inputs = ops.convert_to_tensor(inputs, dtype=self.dtype)
+    ndim = self._input_rank
+
+    shape = self.gamma.get_shape().as_list()
+    gamma = array_ops.reshape(self.gamma, (ndim - 2) * [1] + shape)
+
+    # Compute normalization pool.
+    if self.data_format == 'channels_first':
+      norm_pool = nn.convolution(
+          math_ops.square(inputs),
+          gamma,
+          'VALID',
+          data_format='NC' + 'DHW' [-(ndim - 2):])
+      if ndim == 3:
+        norm_pool = array_ops.expand_dims(norm_pool, 2)
+        norm_pool = nn.bias_add(norm_pool, self.beta, data_format='NCHW')
+        norm_pool = array_ops.squeeze(norm_pool, [2])
+      elif ndim == 5:
+        shape = array_ops.shape(norm_pool)
+        norm_pool = array_ops.reshape(norm_pool, shape[:3] + [-1])
+        norm_pool = nn.bias_add(norm_pool, self.beta, data_format='NCHW')
+        norm_pool = array_ops.reshape(norm_pool, shape)
+      else:  # ndim == 4
+        norm_pool = nn.bias_add(norm_pool, self.beta, data_format='NCHW')
+    else:  # channels_last
+      norm_pool = nn.convolution(math_ops.square(inputs), gamma, 'VALID')
+      norm_pool = nn.bias_add(norm_pool, self.beta, data_format='NHWC')
+    norm_pool = math_ops.sqrt(norm_pool)
+
+    if self.inverse:
+      outputs = inputs * norm_pool
+    else:
+      outputs = inputs / norm_pool
+    outputs.set_shape(inputs.get_shape())
+    return outputs
+
+  def compute_output_shape(self, input_shape):
+    channel_axis = self._channel_axis()
+    input_shape = tensor_shape.TensorShape(input_shape)
+    if not 3 <= input_shape.ndim <= 5:
+      raise ValueError('`input_shape` must be of rank 3 to 5, inclusive.')
+    if input_shape.dims[channel_axis].value is None:
+      raise ValueError(
+          'The channel dimension of `input_shape` must be defined.')
+    return input_shape
+
+
+ops.RegisterGradient('GDNLowerBound')(GDN._lower_bound_grad)  # pylint:disable=protected-access
+
+
+def gdn(inputs,
+        inverse=False,
+        beta_min=1e-6,
+        gamma_init=.1,
+        reparam_offset=2**-18,
+        data_format='channels_last',
+        activity_regularizer=None,
+        trainable=True,
+        name=None,
+        reuse=None):
+  """Functional interface for GDN layer.
+
+  Based on the papers:
+
+    "Density Modeling of Images using a Generalized Normalization
+    Transformation"
+    Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+    https://arxiv.org/abs/1511.06281
+
+    "End-to-end Optimized Image Compression"
+    Johannes Ballé, Valero Laparra, Eero P. Simoncelli
+    https://arxiv.org/abs/1611.01704
+
+  Implements an activation function that is essentially a multivariate
+  generalization of a particular sigmoid-type function:
+
+  ```
+  y[i] = x[i] / sqrt(beta[i] + sum_j(gamma[j, i] * x[j]))
+  ```
+
+  where `i` and `j` run over channels. This implementation never sums across
+  spatial dimensions. It is similar to local response normalization, but much
+  more flexible, as `beta` and `gamma` are trainable parameters.
+
+  Args:
+    inputs: Tensor input.
+    inverse: If `False` (default), compute GDN response. If `True`, compute IGDN
+      response (one step of fixed point iteration to invert GDN; the division is
+      replaced by multiplication).
+    beta_min: Lower bound for beta, to prevent numerical error from causing
+      square root of zero or negative values.
+    gamma_init: The gamma matrix will be initialized as the identity matrix
+      multiplied with this value. If set to zero, the layer is effectively
+      initialized to the identity operation, since beta is initialized as one. A
+      good default setting is somewhere between 0 and 0.5.
+    reparam_offset: Offset added to the reparameterization of beta and gamma.
+      The reparameterization of beta and gamma as their square roots lets the
+      training slow down when their values are close to zero, which is desirable
+      as small values in the denominator can lead to a situation where gradient
+      noise on beta/gamma leads to extreme amounts of noise in the GDN
+      activations. However, without the offset, we would get zero gradients if
+      any elements of beta or gamma were exactly zero, and thus the training
+      could get stuck. To prevent this, we add this small constant. The default
+      value was empirically determined as a good starting point. Making it
+      bigger potentially leads to more gradient noise on the activations, making
+      it too small may lead to numerical precision issues.
+    data_format: Format of input tensor. Currently supports `'channels_first'`
+      and `'channels_last'`.
+    activity_regularizer: Regularizer function for the output.
+    trainable: Boolean, if `True`, also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    name: String, the name of the layer. Layers with the same name will share
+      weights, but to avoid mistakes we require `reuse=True` in such cases.
+    reuse: Boolean, whether to reuse the weights of a previous layer by the same
+      name.
+
+  Returns:
+    Output tensor.
+  """
+  layer = GDN(
+      inverse=inverse,
+      beta_min=beta_min,
+      gamma_init=gamma_init,
+      reparam_offset=reparam_offset,
+      data_format=data_format,
+      activity_regularizer=activity_regularizer,
+      trainable=trainable,
+      name=name,
+      dtype=inputs.dtype.base_dtype,
+      _scope=name,
+      _reuse=reuse)
+  return layer.apply(inputs)
+
+
+@add_arg_scope
+def layer_norm(inputs,
+               center=True,
+               scale=True,
+               activation_fn=None,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               begin_norm_axis=1,
+               begin_params_axis=-1,
+               scope=None):
+  """Adds a Layer Normalization layer.
+
+  Based on the paper:
+
+    "Layer Normalization"
+
+    Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton
+
+    https://arxiv.org/abs/1607.06450.
+
+  Can be used as a normalizer function for conv2d and fully_connected.
+
+  Given a tensor `inputs` of rank `R`, moments are calculated and normalization
+  is performed over axes `begin_norm_axis ... R - 1`.  Scaling and centering,
+  if requested, is performed over axes `begin_params_axis .. R - 1`.
+
+  By default, `begin_norm_axis = 1` and `begin_params_axis = -1`,
+  meaning that normalization is performed over all but the first axis
+  (the `HWC` if `inputs` is `NHWC`), while the `beta` and `gamma` trainable
+  parameters are calculated for the rightmost axis (the `C` if `inputs` is
+  `NHWC`).  Scaling and recentering is performed via broadcast of the
+  `beta` and `gamma` parameters with the normalized tensor.
+
+  The shapes of `beta` and `gamma` are `inputs.shape[begin_params_axis:]`,
+  and this part of the inputs' shape must be fully defined.
+
+  Args:
+    inputs: A tensor having rank `R`. The normalization is performed over axes
+      `begin_norm_axis ... R - 1` and centering and scaling parameters are
+      calculated over `begin_params_axis ... R - 1`.
+    center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+      is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is not used. When the
+      next layer is linear (also e.g. `nn.relu`), this can be disabled since the
+      scaling can be done by the next layer.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    begin_norm_axis: The first normalization dimension: normalization will be
+      performed along dimensions `begin_norm_axis : rank(inputs)`
+    begin_params_axis: The first parameter (beta, gamma) dimension: scale and
+      centering parameters will have dimensions
+      `begin_params_axis : rank(inputs)` and will be broadcast with the
+        normalized inputs accordingly.
+    scope: Optional scope for `variable_scope`.
+
+  Returns:
+    A `Tensor` representing the output of the operation, having the same
+    shape and dtype as `inputs`.
+
+  Raises:
+    ValueError: If the rank of `inputs` is not known at graph build time,
+      or if `inputs.shape[begin_params_axis:]` is not fully defined at
+      graph build time.
+  """
+  with variable_scope.variable_scope(
+      scope, 'LayerNorm', [inputs], reuse=reuse) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    inputs_shape = inputs.shape
+    inputs_rank = inputs_shape.ndims
+    if inputs_rank is None:
+      raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+    dtype = inputs.dtype.base_dtype
+    if begin_norm_axis < 0:
+      begin_norm_axis = inputs_rank + begin_norm_axis
+    if begin_params_axis >= inputs_rank or begin_norm_axis >= inputs_rank:
+      raise ValueError('begin_params_axis (%d) and begin_norm_axis (%d) '
+                       'must be < rank(inputs) (%d)' %
+                       (begin_params_axis, begin_norm_axis, inputs_rank))
+    params_shape = inputs_shape[begin_params_axis:]
+    if not params_shape.is_fully_defined():
+      raise ValueError(
+          'Inputs %s: shape(inputs)[%s:] is not fully defined: %s' %
+          (inputs.name, begin_params_axis, inputs_shape))
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta, gamma = None, None
+    if center:
+      beta_collections = utils.get_variable_collections(variables_collections,
+                                                        'beta')
+      beta = variables.model_variable(
+          'beta',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=init_ops.zeros_initializer(),
+          collections=beta_collections,
+          trainable=trainable)
+    if scale:
+      gamma_collections = utils.get_variable_collections(
+          variables_collections, 'gamma')
+      gamma = variables.model_variable(
+          'gamma',
+          shape=params_shape,
+          dtype=dtype,
+          initializer=init_ops.ones_initializer(),
+          collections=gamma_collections,
+          trainable=trainable)
+    # By default, compute the moments across all the dimensions except the one with index 0.
+    norm_axes = list(range(begin_norm_axis, inputs_rank))
+    mean, variance = nn.moments(inputs, norm_axes, keep_dims=True)
+    # Compute layer normalization using the batch_normalization function.
+    # Note that epsilon must be increased for float16 due to the limited
+    # representable range.
+    variance_epsilon = 1e-12 if dtype != dtypes.float16 else 1e-3
+    outputs = nn.batch_normalization(
+        inputs,
+        mean,
+        variance,
+        offset=beta,
+        scale=gamma,
+        variance_epsilon=variance_epsilon)
+    outputs.set_shape(inputs_shape)
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def images_to_sequence(inputs,
+                       data_format=DATA_FORMAT_NHWC,
+                       outputs_collections=None,
+                       scope=None):
+  """Convert a batch of images into a batch of sequences.
+
+  Args:
+    inputs: a (num_images, height, width, depth) tensor
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Raises:
+     ValueError: If `data_format` is not either NCHW or NHWC.
+
+  Returns:
+    (width, num_images*height, depth) sequence tensor
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  with ops.name_scope(scope, 'ImagesToSequence', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    if df == 'channels_first':
+      inputs = array_ops.transpose(inputs, [0, 2, 3, 1])
+    _, _, width, depth = inputs.get_shape().as_list()
+    s = array_ops.shape(inputs)
+    batch_size, height = s[0], s[1]
+    transposed = array_ops.transpose(inputs, [2, 0, 1, 3])
+    outputs = array_ops.reshape(transposed, [width, batch_size * height, depth])
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def max_pool2d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NHWC,
+               outputs_collections=None,
+               scope=None):
+  """Adds a 2D Max Pooling op.
+
+  It is assumed that the pooling is done per image but not in batch or channels.
+
+  Args:
+    inputs: A 4-D tensor of shape `[batch_size, height, width, channels]` if
+      `data_format` is `NHWC`, and `[batch_size, channels, height, width]` if
+      `data_format` is `NCHW`.
+    kernel_size: A list of length 2: [kernel_height, kernel_width] of the
+      pooling kernel over which the op is computed. Can be an int if both values
+      are the same.
+    stride: A list of length 2: [stride_height, stride_width]. Can be an int if
+      both strides are the same. Note that presently both strides must have the
+      same value.
+    padding: The padding method, either 'VALID' or 'SAME'.
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If 'kernel_size' is not a 2-D list
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  with ops.name_scope(scope, 'MaxPool2D', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = pooling_layers.MaxPooling2D(
+        pool_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        _scope=sc)
+    outputs = layer.apply(inputs)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def max_pool3d(inputs,
+               kernel_size,
+               stride=2,
+               padding='VALID',
+               data_format=DATA_FORMAT_NDHWC,
+               outputs_collections=None,
+               scope=None):
+  """Adds a 3D Max Pooling op.
+
+  It is assumed that the pooling is done per image but not in batch or channels.
+
+  Args:
+    inputs: A 5-D tensor of shape `[batch_size, depth, height, width, channels]`
+      if `data_format` is `NDHWC`, and `[batch_size, channels, depth, height,
+      width]` if `data_format` is `NCDHW`.
+    kernel_size: A list of length 3: [kernel_depth, kernel_height, kernel_width]
+      of the pooling kernel over which the op is computed. Can be an int if both
+      values are the same.
+    stride: A list of length 3: [stride_depth, stride_height, stride_width]. Can
+      be an int if both strides are the same. Note that presently both strides
+      must have the same value.
+    padding: The padding method, either 'VALID' or 'SAME'.
+    data_format: A string. `NDHWC` (default) and `NCDHW` are supported.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NDHWC` nor `NCDHW`.
+    ValueError: If 'kernel_size' is not a 3-D list
+  """
+  if data_format not in (DATA_FORMAT_NCDHW, DATA_FORMAT_NDHWC):
+    raise ValueError('data_format has to be either NCDHW or NDHWC.')
+  with ops.name_scope(scope, 'MaxPool3D', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    layer = pooling_layers.MaxPooling3D(
+        pool_size=kernel_size,
+        strides=stride,
+        padding=padding,
+        data_format=df,
+        _scope=sc)
+    outputs = layer.apply(inputs)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def pool(inputs,
+         kernel_size,
+         pooling_type,
+         padding='VALID',
+         data_format=None,
+         dilation_rate=1,
+         stride=1,
+         outputs_collections=None,
+         scope=None):
+  # pylint: disable=line-too-long
+  """Adds a pooling op.
+
+
+  Args:
+    inputs: Tensor of rank N+2, of shape `[batch_size] + input_spatial_shape +
+      [num_channels]` if data_format does not start with "NC" (default), or
+      `[batch_size, num_channels] + input_spatial_shape` if data_format starts
+      with "NC".  Pooling happens over the spatial dimensions only.
+    kernel_size: Sequence of N ints >= 1.  Can also be a single integer to
+      specify the same value for all spatial dimensions.
+    pooling_type: Specifies pooling operation, must be "AVG" or "MAX".
+    padding: The padding algorithm, must be "SAME" or "VALID".
+    data_format: A string or None.  Specifies whether the channel dimension of
+      the `input` and output is the last dimension (default, or if `data_format`
+      does not start with "NC"), or the second dimension (if `data_format`
+      starts with "NC").  For N=1, the valid values are "NWC" (default) and
+      "NCW".  For N=2, the valid values are "NHWC" (default) and "NCHW". For
+      N=3, the valid values are "NDHWC" (default) and "NCDHW".
+    dilation_rate: Optional.  Dilation rate.  Sequence of N ints >= 1.  Defaults
+      to [1]*N.  Can also be a single integer to specify the same value for all
+      spatial dimensions.  If any value of dilation_rate is > 1, then all values
+      of stride must be 1.
+    stride: Optional.  Sequence of N ints >= 1.  Defaults to [1]*N.  Can also be
+      a single integer to specify the same value for all spatial dimensions.  If
+      any value of stride is > 1, then all values of dilation_rate must be 1.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: If arguments are invalid.
+
+  """
+  # pylint: enable=line-too-long
+  with ops.name_scope(scope, '%s_pool' % (pooling_type.lower()),
+                      [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    input_rank = inputs.get_shape().ndims
+    if input_rank is None:
+      raise ValueError('Rank of inputs must be known')
+    if input_rank < 3:
+      raise ValueError('Rank of inputs must be >= 3')
+    num_spatial_dims = input_rank - 2
+    output = nn.pool(
+        input=inputs,
+        window_shape=utils.n_positive_integers(num_spatial_dims, kernel_size),
+        pooling_type=pooling_type,
+        padding=padding,
+        data_format=data_format,
+        dilation_rate=utils.n_positive_integers(num_spatial_dims,
+                                                dilation_rate),
+        strides=utils.n_positive_integers(num_spatial_dims, stride),
+        name=sc)
+    return utils.collect_named_outputs(outputs_collections, sc, output)
+
+
+@add_arg_scope
+def one_hot_encoding(labels,
+                     num_classes,
+                     on_value=1.0,
+                     off_value=0.0,
+                     outputs_collections=None,
+                     scope=None):
+  """Transform numeric labels into onehot_labels using `tf.one_hot`.
+
+  Args:
+    labels: [batch_size] target labels.
+    num_classes: Total number of classes.
+    on_value: A scalar defining the on-value.
+    off_value: A scalar defining the off-value.
+    outputs_collections: Collection to add the outputs.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    One-hot encoding of the labels.
+  """
+  with ops.name_scope(scope, 'OneHotEncoding', [labels, num_classes]) as sc:
+    labels = ops.convert_to_tensor(labels)
+    if labels.dtype == dtypes.int32:
+      labels = standard_ops.to_int64(labels)
+    outputs = standard_ops.one_hot(
+        labels, num_classes, on_value=on_value, off_value=off_value)
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+def _apply_activation(y, activation_fn, output_collections):
+  if activation_fn is not None:
+    y = activation_fn(y)
+  ops.add_to_collections(
+      list(output_collections or []) + [ops.GraphKeys.ACTIVATIONS], y)
+  return y
+
+
+def repeat(inputs, repetitions, layer, *args, **kwargs):
+  """Applies the same layer with the same arguments repeatedly.
+
+  ```python
+    y = repeat(x, 3, conv2d, 64, [3, 3], scope='conv1')
+    # It is equivalent to:
+
+    x = conv2d(x, 64, [3, 3], scope='conv1/conv1_1')
+    x = conv2d(x, 64, [3, 3], scope='conv1/conv1_2')
+    y = conv2d(x, 64, [3, 3], scope='conv1/conv1_3')
+  ```
+
+  If the `scope` argument is not given in `kwargs`, it is set to
+  `layer.__name__`, or `layer.func.__name__` (for `functools.partial`
+  objects). If neither `__name__` nor `func.__name__` is available, the
+  layers are called with `scope='stack'`.
+
+  Args:
+    inputs: A `Tensor` suitable for layer.
+    repetitions: Int, number of repetitions.
+    layer: A layer with arguments `(inputs, *args, **kwargs)`
+    *args: Extra args for the layer.
+    **kwargs: Extra kwargs for the layer.
+
+  Returns:
+    A tensor result of applying the layer, repetitions times.
+  Raises:
+    ValueError: If the op is unknown or wrong.
+  """
+  scope = kwargs.pop('scope', None)
+  with variable_scope.variable_scope(scope, 'Repeat', [inputs]):
+    inputs = ops.convert_to_tensor(inputs)
+    if scope is None:
+      if hasattr(layer, '__name__'):
+        scope = layer.__name__
+      elif hasattr(layer, 'func') and hasattr(layer.func, '__name__'):
+        scope = layer.func.__name__  # In case layer is a functools.partial.
+      else:
+        scope = 'repeat'
+    outputs = inputs
+    for i in range(repetitions):
+      kwargs['scope'] = scope + '_' + str(i + 1)
+      outputs = layer(outputs, *args, **kwargs)
+    return outputs
+
+
+def _scale_gradient_shape(op):
+  """Shape helper function for scale_gradient function below."""
+  return [op.inputs[0].shape]
+
+
+def _scale_gradient_grad(op, grad):
+  """Python gradient helper function for scale_gradient function below."""
+  return [grad * op.inputs[1], None]
+
+
+@function.Defun(
+    python_grad_func=_scale_gradient_grad, shape_func=_scale_gradient_shape)
+def scale_gradient(inputs, gradient_multiplier):
+  """Identity operation, but with the gradient multiplied by a tensor.
+
+  The TensorFlow gradient system will compute the gradient with respect to
+  `inputs` as the product of the gradient with respect to the `output`
+  multiplied by a specified `gradient_multiplier` tensor.  If
+  `gradient_multiplier` is equal to 1, then this results in the true gradient.
+  Otherwise, it results in a scaled gradient.
+
+  This can be useful for adjusting the relative learning rate of different
+  parameter tensors when performing gradient descent, and because this rescaling
+  can be inserted at arbitrary locations within a graph, is often more
+  convenient to apply than simply rescaling the final computed gradients.
+
+  Args:
+    inputs: Tensor to be output.
+    gradient_multiplier: Tensor by which to multiply the gradient with respect
+      to `output` to compute the gradient with respect to `inputs`.  Its shape
+      must be broadcastable to the shape of `inputs`.
+
+  Returns:
+    output Tensor, equal to `inputs`.
+  """
+  # gradient_multiplier is implicitly saved by decorator, and only used for
+  # gradient computation.
+  del gradient_multiplier
+
+  return inputs
+
+
+@add_arg_scope
+def separable_convolution2d(
+    inputs,
+    num_outputs,
+    kernel_size,
+    depth_multiplier=1,
+    stride=1,
+    padding='SAME',
+    data_format=DATA_FORMAT_NHWC,
+    rate=1,
+    activation_fn=nn.relu,
+    normalizer_fn=None,
+    normalizer_params=None,
+    weights_initializer=initializers.xavier_initializer(),
+    pointwise_initializer=None,
+    weights_regularizer=None,
+    biases_initializer=init_ops.zeros_initializer(),
+    biases_regularizer=None,
+    reuse=None,
+    variables_collections=None,
+    outputs_collections=None,
+    trainable=True,
+    scope=None):
+  """Adds a depth-separable 2D convolution with optional batch_norm layer.
+
+  This op first performs a depthwise convolution that acts separately on
+  channels, creating a variable called `depthwise_weights`. If `num_outputs`
+  is not None, it adds a pointwise convolution that mixes channels, creating a
+  variable called `pointwise_weights`. Then, if `normalizer_fn` is None,
+  it adds bias to the result, creating a variable called 'biases', otherwise,
+  the `normalizer_fn` is applied. It finally applies an activation function
+  to produce the end result.
+
+  Args:
+    inputs: A tensor of size [batch_size, height, width, channels].
+    num_outputs: The number of pointwise convolution output filters. If is None,
+      then we skip the pointwise convolution stage.
+    kernel_size: A list of length 2: [kernel_height, kernel_width] of of the
+      filters. Can be an int if both values are the same.
+    depth_multiplier: The number of depthwise convolution output channels for
+      each input channel. The total number of depthwise convolution output
+      channels will be equal to `num_filters_in * depth_multiplier`.
+    stride: A list of length 2: [stride_height, stride_width], specifying the
+      depthwise convolution stride. Can be an int if both strides are the same.
+    padding: One of 'VALID' or 'SAME'.
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    rate: A list of length 2: [rate_height, rate_width], specifying the dilation
+      rates for atrous convolution. Can be an int if both rates are the same. If
+      any value is larger than one, then both stride values need to be one.
+    activation_fn: Activation function. The default value is a ReLU function.
+      Explicitly set it to None to skip it and maintain a linear activation.
+    normalizer_fn: Normalization function to use instead of `biases`. If
+      `normalizer_fn` is provided then `biases_initializer` and
+      `biases_regularizer` are ignored and `biases` are not created nor added.
+      default set to None for no normalizer function
+    normalizer_params: Normalization function parameters.
+    weights_initializer: An initializer for the depthwise weights.
+    pointwise_initializer: An initializer for the pointwise weights. default set
+      to None, means use weights_initializer.
+    weights_regularizer: Optional regularizer for the weights.
+    biases_initializer: An initializer for the biases. If None skip biases.
+    biases_regularizer: Optional regularizer for the biases.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional list of collections for all the variables or
+      a dictionary containing a different list of collection per variable.
+    outputs_collections: Collection to add the outputs.
+    trainable: Whether or not the variables should be trainable or not.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+  Raises:
+    ValueError: If `data_format` is invalid.
+  """
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+  layer_variable_getter = _build_variable_getter({
+      'bias': 'biases',
+      'depthwise_kernel': 'depthwise_weights',
+      'pointwise_kernel': 'pointwise_weights'
+  })
+
+  with variable_scope.variable_scope(
+      scope,
+      'SeparableConv2d', [inputs],
+      reuse=reuse,
+      custom_getter=layer_variable_getter) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+
+    if pointwise_initializer is None:
+      pointwise_initializer = weights_initializer
+
+    df = ('channels_first'
+          if data_format and data_format.startswith('NC') else 'channels_last')
+    if num_outputs is not None:
+      # Apply separable conv using the SeparableConvolution2D layer.
+      layer = convolutional_layers.SeparableConvolution2D(
+          filters=num_outputs,
+          kernel_size=kernel_size,
+          strides=stride,
+          padding=padding,
+          data_format=df,
+          dilation_rate=utils.two_element_tuple(rate),
+          activation=None,
+          depth_multiplier=depth_multiplier,
+          use_bias=not normalizer_fn and biases_initializer,
+          depthwise_initializer=weights_initializer,
+          pointwise_initializer=pointwise_initializer,
+          bias_initializer=biases_initializer,
+          depthwise_regularizer=weights_regularizer,
+          pointwise_regularizer=weights_regularizer,
+          bias_regularizer=biases_regularizer,
+          activity_regularizer=None,
+          trainable=trainable,
+          name=sc.name,
+          dtype=inputs.dtype.base_dtype,
+          _scope=sc,
+          _reuse=reuse)
+      outputs = layer.apply(inputs)
+
+      # Add variables to collections.
+      _add_variable_to_collections(layer.depthwise_kernel,
+                                   variables_collections, 'weights')
+      _add_variable_to_collections(layer.pointwise_kernel,
+                                   variables_collections, 'weights')
+      if layer.bias is not None:
+        _add_variable_to_collections(layer.bias, variables_collections,
+                                     'biases')
+
+      if normalizer_fn is not None:
+        normalizer_params = normalizer_params or {}
+        outputs = normalizer_fn(outputs, **normalizer_params)
+    else:
+      # Actually apply depthwise conv instead of separable conv.
+      dtype = inputs.dtype.base_dtype
+      kernel_h, kernel_w = utils.two_element_tuple(kernel_size)
+      stride_h, stride_w = utils.two_element_tuple(stride)
+      num_filters_in = utils.channel_dimension(
+          inputs.get_shape(), df, min_rank=4)
+      weights_collections = utils.get_variable_collections(
+          variables_collections, 'weights')
+
+      depthwise_shape = [kernel_h, kernel_w, num_filters_in, depth_multiplier]
+      depthwise_weights = variables.model_variable(
+          'depthwise_weights',
+          shape=depthwise_shape,
+          dtype=dtype,
+          initializer=weights_initializer,
+          regularizer=weights_regularizer,
+          trainable=trainable,
+          collections=weights_collections)
+      strides = [
+          1, 1, stride_h, stride_w
+      ] if data_format.startswith('NC') else [1, stride_h, stride_w, 1]
+
+      outputs = nn.depthwise_conv2d(
+          inputs,
+          depthwise_weights,
+          strides,
+          padding,
+          rate=utils.two_element_tuple(rate),
+          data_format=data_format)
+      num_outputs = depth_multiplier * num_filters_in
+
+      if normalizer_fn is not None:
+        normalizer_params = normalizer_params or {}
+        outputs = normalizer_fn(outputs, **normalizer_params)
+      else:
+        if biases_initializer is not None:
+          biases_collections = utils.get_variable_collections(
+              variables_collections, 'biases')
+          biases = variables.model_variable(
+              'biases',
+              shape=[
+                  num_outputs,
+              ],
+              dtype=dtype,
+              initializer=biases_initializer,
+              regularizer=biases_regularizer,
+              trainable=trainable,
+              collections=biases_collections)
+          outputs = nn.bias_add(outputs, biases, data_format=data_format)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def sequence_to_images(inputs,
+                       height,
+                       output_data_format='channels_last',
+                       outputs_collections=None,
+                       scope=None):
+  """Convert a batch of sequences into a batch of images.
+
+  Args:
+    inputs: (num_steps, num_batches, depth) sequence tensor
+    height: the height of the images
+    output_data_format: Format of output tensor. Currently supports
+      `'channels_first'` and `'channels_last'`.
+    outputs_collections: The collections to which the outputs are added.
+    scope: Optional scope for name_scope.
+
+  Returns:
+    A tensor representing the output of the operation.
+  """
+  with ops.name_scope(scope, 'SequenceToImages', [inputs]) as sc:
+    inputs = ops.convert_to_tensor(inputs)
+    width, num_batches, depth = inputs.get_shape().as_list()
+    if num_batches is None:
+      num_batches = -1
+    else:
+      num_batches //= height
+    reshaped = array_ops.reshape(inputs, [width, num_batches, height, depth])
+    if output_data_format == 'channels_first':
+      outputs = array_ops.transpose(reshaped, [1, 3, 2, 0])
+    else:
+      outputs = array_ops.transpose(reshaped, [1, 2, 0, 3])
+    return utils.collect_named_outputs(outputs_collections, sc, outputs)
+
+
+@add_arg_scope
+def softmax(logits, scope=None):
+  """Performs softmax on Nth dimension of N-dimensional logit tensor.
+
+  For two-dimensional logits this reduces to tf.nn.softmax. The N-th dimension
+  needs to have a specified number of elements (number of classes).
+
+  Args:
+    logits: N-dimensional `Tensor` with logits, where N > 1.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A `Tensor` with same shape and type as logits.
+  """
+  # TODO(jrru): Add axis argument which defaults to last dimension.
+  with variable_scope.variable_scope(scope, 'softmax', [logits]):
+    num_logits = utils.last_dimension(logits.get_shape(), min_rank=2)
+    logits_2d = array_ops.reshape(logits, [-1, num_logits])
+    predictions = nn.softmax(logits_2d)
+    predictions = array_ops.reshape(predictions, array_ops.shape(logits))
+    if not context.executing_eagerly():
+      predictions.set_shape(logits.get_shape())
+    return predictions
+
+
+@add_arg_scope
+def spatial_softmax(features,
+                    temperature=None,
+                    name=None,
+                    variables_collections=None,
+                    trainable=True,
+                    data_format='NHWC'):
+  """Computes the spatial softmax of a convolutional feature map.
+
+  First computes the softmax over the spatial extent of each channel of a
+  convolutional feature map. Then computes the expected 2D position of the
+  points of maximal activation for each channel, resulting in a set of
+  feature keypoints [i1, j1, ... iN, jN] for all N channels.
+
+  Read more here:
+  "Learning visual feature spaces for robotic manipulation with
+  deep spatial autoencoders." Finn et al., http://arxiv.org/abs/1509.06113.
+
+  Args:
+    features: A `Tensor` of size [batch_size, W, H, num_channels]; the
+      convolutional feature map.
+    temperature: Softmax temperature (optional). If None, a learnable
+      temperature is created.
+    name: A name for this operation (optional).
+    variables_collections: Collections for the temperature variable.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+
+  Returns:
+    feature_keypoints: A `Tensor` with size [batch_size, num_channels * 2];
+      the expected 2D locations of each channel's feature keypoint (normalized
+      to the range (-1,1)). The inner dimension is arranged as
+      [i1, j1, ... iN, jN].
+  Raises:
+    ValueError: If unexpected data_format specified.
+    ValueError: If num_channels dimension is unspecified.
+  """
+  with variable_scope.variable_scope(name, 'spatial_softmax'):
+    shape = array_ops.shape(features)
+    static_shape = features.shape
+    if data_format == DATA_FORMAT_NHWC:
+      height, width, num_channels = shape[1], shape[2], static_shape[3]
+    elif data_format == DATA_FORMAT_NCHW:
+      num_channels, height, width = static_shape[1], shape[2], shape[3]
+    else:
+      raise ValueError('data_format has to be either NCHW or NHWC.')
+    if tensor_shape.dimension_value(num_channels) is None:
+      raise ValueError('The num_channels dimension of the inputs to '
+                       '`spatial_softmax` should be defined. Found `None`.')
+
+    with ops.name_scope('spatial_softmax_op', 'spatial_softmax_op', [features]):
+      # Create tensors for x and y coordinate values, scaled to range [-1, 1].
+      pos_x, pos_y = array_ops.meshgrid(
+          math_ops.lin_space(-1., 1., num=height),
+          math_ops.lin_space(-1., 1., num=width),
+          indexing='ij')
+      pos_x = array_ops.reshape(pos_x, [height * width])
+      pos_y = array_ops.reshape(pos_y, [height * width])
+
+      if temperature is None:
+        temp_initializer = init_ops.ones_initializer()
+      else:
+        temp_initializer = init_ops.constant_initializer(temperature)
+
+      if not trainable:
+        temp_collections = None
+      else:
+        temp_collections = utils.get_variable_collections(
+            variables_collections, 'temperature')
+
+      temperature = variables.model_variable(
+          'temperature',
+          shape=(),
+          dtype=dtypes.float32,
+          initializer=temp_initializer,
+          collections=temp_collections,
+          trainable=trainable)
+      if data_format == 'NCHW':
+        features = array_ops.reshape(features, [-1, height * width])
+      else:
+        features = array_ops.reshape(
+            array_ops.transpose(features, [0, 3, 1, 2]), [-1, height * width])
+
+      softmax_attention = nn.softmax(features / temperature)
+      expected_x = math_ops.reduce_sum(
+          pos_x * softmax_attention, [1], keepdims=True)
+      expected_y = math_ops.reduce_sum(
+          pos_y * softmax_attention, [1], keepdims=True)
+      expected_xy = array_ops.concat([expected_x, expected_y], 1)
+      feature_keypoints = array_ops.reshape(
+          expected_xy, [-1, tensor_shape.dimension_value(num_channels) * 2])
+      feature_keypoints.set_shape(
+          [None, tensor_shape.dimension_value(num_channels) * 2])
+  return feature_keypoints
+
+
+def stack(inputs, layer, stack_args, **kwargs):
+  """Builds a stack of layers by applying layer repeatedly using stack_args.
+
+  `stack` allows you to repeatedly apply the same operation with different
+  arguments `stack_args[i]`. For each application of the layer, `stack` creates
+  a new scope appended with an increasing number. For example:
+
+  ```python
+    y = stack(x, fully_connected, [32, 64, 128], scope='fc')
+    # It is equivalent to:
+
+    x = fully_connected(x, 32, scope='fc/fc_1')
+    x = fully_connected(x, 64, scope='fc/fc_2')
+    y = fully_connected(x, 128, scope='fc/fc_3')
+  ```
+
+  If the `scope` argument is not given in `kwargs`, it is set to
+  `layer.__name__`, or `layer.func.__name__` (for `functools.partial`
+  objects). If neither `__name__` nor `func.__name__` is available, the
+  layers are called with `scope='stack'`.
+
+  Args:
+    inputs: A `Tensor` suitable for layer.
+    layer: A layer with arguments `(inputs, *args, **kwargs)`
+    stack_args: A list/tuple of parameters for each call of layer.
+    **kwargs: Extra kwargs for the layer.
+
+  Returns:
+    A `Tensor` result of applying the stacked layers.
+
+  Raises:
+    ValueError: If the op is unknown or wrong.
+  """
+  scope = kwargs.pop('scope', None)
+  if not isinstance(stack_args, (list, tuple)):
+    raise ValueError('stack_args need to be a list or tuple')
+  with variable_scope.variable_scope(scope, 'Stack', [inputs]):
+    inputs = ops.convert_to_tensor(inputs)
+    if scope is None:
+      if hasattr(layer, '__name__'):
+        scope = layer.__name__
+      elif hasattr(layer, 'func') and hasattr(layer.func, '__name__'):
+        scope = layer.func.__name__  # In case layer is a functools.partial.
+      else:
+        scope = 'stack'
+    outputs = inputs
+    for i in range(len(stack_args)):
+      kwargs['scope'] = scope + '_' + str(i + 1)
+      layer_args = stack_args[i]
+      if not isinstance(layer_args, (list, tuple)):
+        layer_args = [layer_args]
+      outputs = layer(outputs, *layer_args, **kwargs)
+    return outputs
+
+
+@add_arg_scope
+def unit_norm(inputs, dim, epsilon=1e-7, scope=None):
+  """Normalizes the given input across the specified dimension to unit length.
+
+  Note that the rank of `input` must be known.
+
+  Args:
+    inputs: A `Tensor` of arbitrary size.
+    dim: The dimension along which the input is normalized.
+    epsilon: A small value to add to the inputs to avoid dividing by zero.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    The normalized `Tensor`.
+
+  Raises:
+    ValueError: If dim is smaller than the number of dimensions in 'inputs'.
+  """
+  with variable_scope.variable_scope(scope, 'UnitNorm', [inputs]):
+    if not inputs.get_shape():
+      raise ValueError('The input rank must be known.')
+    input_rank = len(inputs.get_shape().as_list())
+    if dim < 0 or dim >= input_rank:
+      raise ValueError('dim must be positive but smaller than the input rank.')
+
+    lengths = math_ops.sqrt(
+        epsilon + math_ops.reduce_sum(math_ops.square(inputs), dim, True))
+    multiples = []
+    if dim > 0:
+      multiples.append(array_ops.ones([dim], dtypes.int32))
+    multiples.append(
+        array_ops.strided_slice(array_ops.shape(inputs), [dim], [dim + 1]))
+    if dim < (input_rank - 1):
+      multiples.append(array_ops.ones([input_rank - 1 - dim], dtypes.int32))
+    multiples = array_ops.concat(multiples, 0)
+    return math_ops.div(inputs, array_ops.tile(lengths, multiples))
+
+
+@add_arg_scope
+def maxout(inputs, num_units, axis=-1, scope=None):
+  """Adds a maxout op from https://arxiv.org/abs/1302.4389
+
+  "Maxout Networks" Ian J. Goodfellow, David Warde-Farley, Mehdi Mirza, Aaron
+  Courville,
+   Yoshua Bengio
+
+  Usually the operation is performed in the filter/channel dimension. This can
+  also be
+  used after fully-connected layers to reduce number of features.
+
+  Arguments:
+    inputs: Tensor input
+    num_units: Specifies how many features will remain after maxout in the
+      `axis` dimension (usually channel). This must be a factor of number of
+      features.
+    axis: The dimension where max pooling will be performed. Default is the last
+      dimension.
+    scope: Optional scope for variable_scope.
+
+  Returns:
+    A `Tensor` representing the results of the pooling operation.
+
+  Raises:
+    ValueError: if num_units is not multiple of number of features.
+  """
+  with variable_scope.variable_scope(scope, 'MaxOut', [inputs]):
+    inputs = ops.convert_to_tensor(inputs)
+    shape = inputs.get_shape().as_list()
+    num_channels = shape[axis]
+    if num_channels % num_units:
+      raise ValueError('number of features({}) is not '
+                       'a multiple of num_units({})'.format(
+                           num_channels, num_units))
+    shape[axis] = num_units
+    shape += [num_channels // num_units]
+
+    # Dealing with batches with arbitrary sizes
+    for i in range(len(shape)):
+      if shape[i] is None:
+        shape[i] = array_ops.shape(inputs)[i]
+    outputs = math_ops.reduce_max(
+        array_ops.reshape(inputs, shape), -1, keepdims=False)
+    return outputs
+
+
+def poincare_normalize(x, axis=1, epsilon=1e-5, name=None):
+  """Project into the Poincare ball with norm <= 1.0 - epsilon.
+
+  https://en.wikipedia.org/wiki/Poincare_ball_model
+
+  Used in
+  Poincare Embeddings for Learning Hierarchical Representations
+  Maximilian Nickel, Douwe Kiela
+  https://arxiv.org/pdf/1705.08039.pdf
+
+  For a 1-D tensor with `axis = 0`, computes
+
+                (x * (1 - epsilon)) / ||x||     if ||x|| > 1 - epsilon
+      output =
+                 x                              otherwise
+
+  For `x` with more dimensions, independently normalizes each 1-D slice along
+  dimension `axis`.
+
+  Args:
+    x: A `Tensor`.
+    axis: Axis along which to normalize.  A scalar or a vector of integers.
+    epsilon: A small deviation from the edge of the unit sphere for numerical
+      stability.
+    name: A name for this operation (optional).
+
+  Returns:
+    A `Tensor` with the same shape as `x`.
+  """
+  with ops.name_scope(name, 'poincare_normalize', [x]) as name:
+    x = ops.convert_to_tensor(x, name='x')
+    square_sum = math_ops.reduce_sum(math_ops.square(x), axis, keepdims=True)
+    x_inv_norm = math_ops.rsqrt(square_sum)
+    x_inv_norm = math_ops.minimum((1. - epsilon) * x_inv_norm, 1.)
+    return math_ops.multiply(x, x_inv_norm, name=name)
+
+
+def legacy_fully_connected(x,
+                           num_output_units,
+                           activation_fn=None,
+                           weight_init=initializers.xavier_initializer(),
+                           bias_init=init_ops.zeros_initializer(),
+                           name=None,
+                           weight_collections=(ops.GraphKeys.WEIGHTS,),
+                           bias_collections=(ops.GraphKeys.BIASES,),
+                           output_collections=(ops.GraphKeys.ACTIVATIONS,),
+                           trainable=True,
+                           weight_regularizer=None,
+                           bias_regularizer=None):
+  # pylint: disable=anomalous-backslash-in-string
+  r"""Adds the parameters for a fully connected layer and returns the output.
+
+  A fully connected layer is generally defined as a matrix multiply:
+  `y = f(w * x + b)` where `f` is given by `activation_fn`. If
+  `activation_fn` is `None`, the result of `y = w * x + b` is
+  returned.
+
+  If `x` has shape [\\(\text{dim}_0, \text{dim}_1, ..., \text{dim}_n\\)]
+  with more than 2 dimensions (\\(n > 1\\)), then we repeat the matrix
+  multiply along the first dimensions. The result r is a tensor of shape
+  [\\(\text{dim}_0, ..., \text{dim}_{n-1},\\) `num_output_units`],
+  where \\( r_{i_0, ..., i_{n-1}, k} =
+  \sum_{0 \leq j < \text{dim}_n} x_{i_0, ... i_{n-1}, j} \cdot w_{j, k}\\).
+  This is accomplished by reshaping `x` to 2-D
+  [\\(\text{dim}_0 \cdot ... \cdot \text{dim}_{n-1}, \text{dim}_n\\)]
+  before the matrix multiply and afterwards reshaping it to
+  [\\(\text{dim}_0, ..., \text{dim}_{n-1},\\) `num_output_units`].
+
+  This op creates `w` and optionally `b`. Bias (`b`) can be disabled by setting
+  `bias_init` to `None`.
+
+  The variable creation is compatible with `tf.compat.v1.variable_scope` and so
+  can be
+  reused with `tf.compat.v1.variable_scope` or `tf.compat.v1.make_template`.
+
+  Most of the details of variable creation can be controlled by specifying the
+  initializers (`weight_init` and `bias_init`) and in which collections to place
+  the created variables (`weight_collections` and `bias_collections`; note that
+  the variables are always added to the `VARIABLES` collection). The output of
+  the layer can be placed in custom collections using `output_collections`.
+  The collections arguments default to `WEIGHTS`, `BIASES` and `ACTIVATIONS`,
+  respectively.
+
+  A per layer regularization can be specified by setting `weight_regularizer`
+  and `bias_regularizer`, which are applied to the weights and biases
+  respectively, and whose output is added to the `REGULARIZATION_LOSSES`
+  collection.
+
+  Args:
+    x: The input `Tensor`.
+    num_output_units: The size of the output.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    weight_init: An optional weight initialization, defaults to
+      `xavier_initializer`.
+    bias_init: An initializer for the bias, defaults to 0. Set to `None` in
+      order to disable bias.
+    name: The name for this operation is used to name operations and to find
+      variables. If specified it must be unique for this scope, otherwise a
+      unique name starting with "fully_connected" will be created.  See
+      `tf.compat.v1.variable_scope` for details.
+    weight_collections: List of graph collections to which weights are added.
+    bias_collections: List of graph collections to which biases are added.
+    output_collections: List of graph collections to which outputs are added.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see tf.Variable).
+    weight_regularizer: A regularizer like the result of `l1_regularizer` or
+      `l2_regularizer`. Used for weights.
+    bias_regularizer: A regularizer like the result of `l1_regularizer` or
+      `l2_regularizer`. Used for biases.
+
+  Returns:
+    The output of the fully connected layer.
+
+  Raises:
+    ValueError: If x has rank less than 2 or if its last dimension is not set.
+  """
+  with variable_scope.variable_scope(name, 'fully_connected', [x]):
+    x = ops.convert_to_tensor(x)
+    dims = x.get_shape().dims
+    if dims is None:
+      raise ValueError('dims of x must be known but is None')
+    if len(dims) < 2:
+      raise ValueError('rank of x must be at least 2 not: %d' % len(dims))
+    num_input_units = dims[-1].value
+    if num_input_units is None:
+      raise ValueError('last dimension of x must be known but is None')
+    dtype = x.dtype.base_dtype
+
+    weight_collections = set(
+        list(weight_collections or []) + [ops.GraphKeys.GLOBAL_VARIABLES])
+    w = variable_scope.get_variable(
+        'weights',
+        shape=[num_input_units, num_output_units],
+        dtype=dtype,
+        initializer=weight_init,
+        collections=weight_collections,
+        regularizer=weight_regularizer,
+        trainable=trainable)
+    x_2_dim = x if len(dims) <= 2 else array_ops.reshape(
+        x, [-1, num_input_units])
+    y = standard_ops.matmul(x_2_dim, w)
+
+    if bias_init is not None:
+      bias_collections = set(
+          list(bias_collections or []) + [ops.GraphKeys.GLOBAL_VARIABLES])
+      b = variable_scope.get_variable(
+          'bias',
+          shape=[num_output_units],
+          dtype=dtype,
+          initializer=bias_init,
+          collections=bias_collections,
+          regularizer=bias_regularizer,
+          trainable=trainable)
+
+      y = nn.bias_add(y, b)
+
+    if len(dims) > 2:
+      out_shape = array_ops.unstack(array_ops.shape(x))
+      out_shape[-1] = num_output_units
+
+      y = array_ops.reshape(y, array_ops.stack(out_shape))
+
+      static_shape = x.get_shape().as_list()
+      static_shape[-1] = num_output_units
+      y.set_shape(static_shape)
+
+    return _apply_activation(y, activation_fn, output_collections)
+
+
+# TODO(eiderm): Verify and fix autocomplete in colab (also relu6).
+# Simple aliases which remove the activation_fn parameter.
+elu = functools.partial(fully_connected, activation_fn=nn.elu)
+legacy_relu = functools.partial(legacy_fully_connected, activation_fn=nn.relu)
+legacy_linear = functools.partial(legacy_fully_connected, activation_fn=None)
+relu = functools.partial(fully_connected, activation_fn=nn.relu)
+relu6 = functools.partial(fully_connected, activation_fn=nn.relu6)
+linear = functools.partial(fully_connected, activation_fn=None)
+
+# Simple alias.
+conv1d = convolution1d
+conv2d = convolution2d
+conv3d = convolution3d
+conv2d_transpose = convolution2d_transpose
+conv3d_transpose = convolution3d_transpose
+conv2d_in_plane = convolution2d_in_plane
+separable_conv2d = separable_convolution2d

--- a/tensornets/contrib_layers/normalization.py
+++ b/tensornets/contrib_layers/normalization.py
@@ -1,0 +1,391 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+"""Contains the normalization layer classes and their functional aliases."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+
+from ..contrib_framework import add_arg_scope
+from ..contrib_framework import variables
+from . import utils
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.framework import dtypes
+
+__all__ = [
+    'group_norm',
+    'instance_norm',
+]
+
+DATA_FORMAT_NCHW = 'NCHW'
+DATA_FORMAT_NHWC = 'NHWC'
+
+
+@add_arg_scope
+def instance_norm(inputs,
+                  center=True,
+                  scale=True,
+                  epsilon=1e-6,
+                  activation_fn=None,
+                  param_initializers=None,
+                  reuse=None,
+                  variables_collections=None,
+                  outputs_collections=None,
+                  trainable=True,
+                  data_format=DATA_FORMAT_NHWC,
+                  scope=None):
+  """Functional interface for the instance normalization layer.
+
+  Reference: https://arxiv.org/abs/1607.08022.
+
+    "Instance Normalization: The Missing Ingredient for Fast Stylization"
+    Dmitry Ulyanov, Andrea Vedaldi, Victor Lempitsky
+
+  Args:
+    inputs: A tensor with 2 or more dimensions, where the first dimension has
+      `batch_size`. The normalization is over all but the last dimension if
+      `data_format` is `NHWC` and the second dimension if `data_format` is
+      `NCHW`.
+    center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+      is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is
+      not used. When the next layer is linear (also e.g. `nn.relu`), this can be
+      disabled since the scaling can be done by the next layer.
+    epsilon: Small float added to variance to avoid dividing by zero.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    param_initializers: Optional initializers for beta, gamma, moving mean and
+      moving variance.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    data_format: A string. `NHWC` (default) and `NCHW` are supported.
+    scope: Optional scope for `variable_scope`.
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+
+  Raises:
+    ValueError: If `data_format` is neither `NHWC` nor `NCHW`.
+    ValueError: If the rank of `inputs` is undefined.
+    ValueError: If rank or channels dimension of `inputs` is undefined.
+  """
+  inputs = ops.convert_to_tensor(inputs)
+  inputs_shape = inputs.shape
+  inputs_rank = inputs.shape.ndims
+  # For big endian, precision difference in last decimal values getting in
+  # float32 Vs float64 data type is causing normalization_test failure.
+  # The cast to float64 will calculate mean and variance correctly while
+  # normalization of `inputs` tensor.
+  if sys.byteorder == "big" and inputs.dtype.base_dtype == dtypes.float32:
+    inputs = math_ops.cast(inputs, dtypes.float64)
+
+  if inputs_rank is None:
+    raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+  if data_format not in (DATA_FORMAT_NCHW, DATA_FORMAT_NHWC):
+    raise ValueError('data_format has to be either NCHW or NHWC.')
+
+  with variable_scope.variable_scope(
+      scope, 'InstanceNorm', [inputs], reuse=reuse) as sc:
+    if data_format == DATA_FORMAT_NCHW:
+      reduction_axis = 1
+      # For NCHW format, rather than relying on implicit broadcasting, we
+      # explicitly reshape the params to params_shape_broadcast when computing
+      # the moments and the batch normalization.
+      params_shape_broadcast = list(
+          [1, inputs_shape[1].value] + [1 for _ in range(2, inputs_rank)])
+    else:
+      reduction_axis = inputs_rank - 1
+      params_shape_broadcast = None
+    moments_axes = list(range(inputs_rank))
+    del moments_axes[reduction_axis]
+    del moments_axes[0]
+    params_shape = inputs_shape[reduction_axis:reduction_axis + 1]
+    if not params_shape.is_fully_defined():
+      raise ValueError('Inputs %s has undefined channels dimension %s.' % (
+          inputs.name, params_shape))
+
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta, gamma = None, None
+    dtype = inputs.dtype.base_dtype
+    if param_initializers is None:
+      param_initializers = {}
+    if center:
+      beta_collections = utils.get_variable_collections(
+          variables_collections, 'beta')
+      beta_initializer = param_initializers.get(
+          'beta', init_ops.zeros_initializer())
+      beta = variables.model_variable('beta',
+                                      shape=params_shape,
+                                      dtype=dtype,
+                                      initializer=beta_initializer,
+                                      collections=beta_collections,
+                                      trainable=trainable)
+      if params_shape_broadcast:
+        beta = array_ops.reshape(beta, params_shape_broadcast)
+    if scale:
+      gamma_collections = utils.get_variable_collections(
+          variables_collections, 'gamma')
+      gamma_initializer = param_initializers.get(
+          'gamma', init_ops.ones_initializer())
+      gamma = variables.model_variable('gamma',
+                                       shape=params_shape,
+                                       dtype=dtype,
+                                       initializer=gamma_initializer,
+                                       collections=gamma_collections,
+                                       trainable=trainable)
+      if params_shape_broadcast:
+        gamma = array_ops.reshape(gamma, params_shape_broadcast)
+
+    # Calculate the moments (instance activations).
+    mean, variance = nn.moments(inputs, moments_axes, keep_dims=True)
+
+    # Compute instance normalization.
+    outputs = nn.batch_normalization(
+        inputs, mean, variance, beta, gamma, epsilon, name='instancenorm')
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)
+
+
+@add_arg_scope
+def group_norm(inputs,
+               groups=32,
+               channels_axis=-1,
+               reduction_axes=(-3, -2),
+               center=True,
+               scale=True,
+               epsilon=1e-6,
+               activation_fn=None,
+               param_initializers=None,
+               reuse=None,
+               variables_collections=None,
+               outputs_collections=None,
+               trainable=True,
+               scope=None,
+               mean_close_to_zero=False):
+  """Functional interface for the group normalization layer.
+
+  Reference: https://arxiv.org/abs/1803.08494.
+
+    "Group Normalization", Yuxin Wu, Kaiming He
+
+  Args:
+    inputs: A Tensor with at least 2 dimensions one which is channels. All
+     shape dimensions except for batch must be fully defined.
+    groups: Integer. Divide the channels into this number of groups over which
+      normalization statistics are computed. This number must be commensurate
+      with the number of channels in `inputs`.
+    channels_axis: An integer. Specifies index of channels axis which will be
+      broken into `groups`, each of which whose statistics will be computed
+      across. Must be mutually exclusive with `reduction_axes`. Preferred usage
+      is to specify negative integers to be agnostic as to whether a batch
+      dimension is included.
+    reduction_axes: Tuple of integers. Specifies dimensions over which
+       statistics will be accumulated. Must be mutually exclusive with
+       `channels_axis`. Statistics will not be accumulated across axes not
+       specified in `reduction_axes` nor `channel_axis`. Preferred usage is to
+       specify negative integers to be agnostic to whether a batch dimension is
+       included.
+
+      Some sample usage cases:
+        NHWC format: channels_axis=-1, reduction_axes=[-3, -2]
+        NCHW format: channels_axis=-3, reduction_axes=[-2, -1]
+
+    center: If True, add offset of `beta` to normalized tensor. If False, `beta`
+      is ignored.
+    scale: If True, multiply by `gamma`. If False, `gamma` is
+      not used. When the next layer is linear (also e.g. `nn.relu`), this can be
+      disabled since the scaling can be done by the next layer.
+    epsilon: Small float added to variance to avoid dividing by zero.
+    activation_fn: Activation function, default set to None to skip it and
+      maintain a linear activation.
+    param_initializers: Optional initializers for beta, gamma, moving mean and
+      moving variance.
+    reuse: Whether or not the layer and its variables should be reused. To be
+      able to reuse the layer scope must be given.
+    variables_collections: Optional collections for the variables.
+    outputs_collections: Collections to add the outputs.
+    trainable: If `True` also add variables to the graph collection
+      `GraphKeys.TRAINABLE_VARIABLES` (see `tf.Variable`).
+    scope: Optional scope for `variable_scope`.
+    mean_close_to_zero: The mean of `input` before ReLU will be close to zero
+      when batch size >= 4k for Resnet-50 on TPU. If `True`, use
+      `nn.sufficient_statistics` and `nn.normalize_moments` to calculate the
+      variance. This is the same behavior as `fused` equals `True` in batch
+      normalization. If `False`, use `nn.moments` to calculate the variance.
+      When `mean` is close to zero, like 1e-4, use `mean` to calculate the
+      variance may have poor result due to repeated roundoff error and
+      denormalization in `mean`.  When `mean` is large, like 1e2,
+      sum(`input`^2) is so large that only the high-order digits of the elements
+      are being accumulated. Thus, use sum(`input` - `mean`)^2/n to calculate
+      the variance has better accuracy compared to (sum(`input`^2)/n - `mean`^2)
+      when `mean` is large.
+
+
+  Returns:
+    A `Tensor` representing the output of the operation.
+
+  Raises:
+    ValueError: If the rank of `inputs` is undefined.
+    ValueError: If rank or channels dimension of `inputs` is undefined.
+    ValueError: If number of groups is not commensurate with number of channels.
+    ValueError: If reduction_axes or channels_axis are out of bounds.
+    ValueError: If reduction_axes are not mutually exclusive with channels_axis.
+  """
+  # TODO(shlens): Support partially defined shapes for the inputs.
+  inputs = ops.convert_to_tensor(inputs)
+
+  if inputs.shape.ndims is None:
+    raise ValueError('Inputs %s has undefined rank.' % inputs.name)
+  if channels_axis > (inputs.shape.ndims - 1):
+    raise ValueError('Axis is out of bounds.')
+
+  # Use dynamic shape for not fully defined dimensions in the inputs.
+  dyanmic_shape = array_ops.shape(inputs)
+  input_shape_list = []
+  for i, dim in enumerate(inputs.shape):
+    if dim.value is None:
+      input_shape_list.append(dyanmic_shape[i])
+    else:
+      input_shape_list.append(dim)
+
+  # Standardize the channels_axis to be positive and identify # of channels.
+  if channels_axis < 0:
+    channels_axis = inputs.shape.ndims + channels_axis
+  channels = inputs.shape[channels_axis].value
+
+  if channels is None:
+    raise ValueError('Inputs %s has undefined channel dimension: %d.' % (
+        inputs.name, channels_axis))
+
+  # Standardize the reduction_axes to be positive.
+  reduction_axes = list(reduction_axes)
+  for i in range(len(reduction_axes)):
+    if reduction_axes[i] < 0:
+      reduction_axes[i] += inputs.shape.ndims
+
+  for a in reduction_axes:
+    if a > inputs.shape.ndims:
+      raise ValueError('Axis is out of bounds.')
+    if inputs.shape[a].value is None:
+      raise ValueError('Inputs %s has undefined dimensions %d.' % (
+          inputs.name, a))
+    if channels_axis == a:
+      raise ValueError('reduction_axis must be mutually exclusive '
+                       'with channels_axis')
+  if groups > channels:
+    raise ValueError('Invalid groups %d for %d channels.' % (groups, channels))
+  if channels % groups != 0:
+    raise ValueError('%d channels is not commensurate with %d groups.' %
+                     (channels, groups))
+
+  # Determine axes before channels. Some examples of common image formats:
+  #  'NCHW': before = [N], after = [HW]
+  #  'NHWC': before = [NHW], after = []
+  axes_before_channels = input_shape_list[:channels_axis]
+  axes_after_channels = input_shape_list[channels_axis+1:]
+
+  # Manually broadcast the parameters to conform to the number of groups.
+  params_shape_broadcast = ([1] * len(axes_before_channels) +
+                            [groups, channels // groups] +
+                            [1] * len(axes_after_channels))
+
+  # Reshape the input by the group within the channel dimension.
+  inputs_shape = (axes_before_channels + [groups, channels // groups] +
+                  axes_after_channels)
+  inputs = array_ops.reshape(inputs, inputs_shape)
+
+  # Determine the dimensions across which moments are calculated.
+  moments_axes = [channels_axis + 1]
+  for a in reduction_axes:
+    if a > channels_axis:
+      moments_axes.append(a + 1)
+    else:
+      moments_axes.append(a)
+
+  with variable_scope.variable_scope(
+      scope, 'GroupNorm', [inputs], reuse=reuse) as sc:
+    # Note that the params_shape is the number of channels always.
+    params_shape = [channels]
+
+    # Allocate parameters for the beta and gamma of the normalization.
+    beta, gamma = None, None
+    dtype = inputs.dtype.base_dtype
+    if param_initializers is None:
+      param_initializers = {}
+    if center:
+      beta_collections = utils.get_variable_collections(
+          variables_collections, 'beta')
+      beta_initializer = param_initializers.get(
+          'beta', init_ops.zeros_initializer())
+      beta = variables.model_variable('beta',
+                                      shape=params_shape,
+                                      dtype=dtype,
+                                      initializer=beta_initializer,
+                                      collections=beta_collections,
+                                      trainable=trainable)
+      beta = array_ops.reshape(beta, params_shape_broadcast)
+
+    if scale:
+      gamma_collections = utils.get_variable_collections(
+          variables_collections, 'gamma')
+      gamma_initializer = param_initializers.get(
+          'gamma', init_ops.ones_initializer())
+      gamma = variables.model_variable('gamma',
+                                       shape=params_shape,
+                                       dtype=dtype,
+                                       initializer=gamma_initializer,
+                                       collections=gamma_collections,
+                                       trainable=trainable)
+      gamma = array_ops.reshape(gamma, params_shape_broadcast)
+
+    # Calculate the moments.
+    if mean_close_to_zero:
+      # One pass algorithm returns better result when mean is close to zero.
+      counts, means_ss, variance_ss, _ = nn.sufficient_statistics(
+          inputs, moments_axes, keep_dims=True)
+      mean, variance = nn.normalize_moments(
+          counts, means_ss, variance_ss, shift=None)
+    else:
+      mean, variance = nn.moments(inputs, moments_axes, keep_dims=True)
+
+    # Compute normalization.
+    # TODO(shlens): Fix nn.batch_normalization to handle the 5-D Tensor
+    # appropriately so that this operation may be faster.
+    gain = math_ops.rsqrt(variance + epsilon)
+    offset = -mean * gain
+    if gamma is not None:
+      gain *= gamma
+      offset *= gamma
+    if beta is not None:
+      offset += beta
+    outputs = inputs * gain + offset
+
+    # Collapse the groups into the channel dimension.
+    outputs = array_ops.reshape(outputs, input_shape_list)
+
+    if activation_fn is not None:
+      outputs = activation_fn(outputs)
+    return utils.collect_named_outputs(outputs_collections, sc.name, outputs)

--- a/tensornets/contrib_layers/optimizers.py
+++ b/tensornets/contrib_layers/optimizers.py
@@ -1,0 +1,440 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Optimizer ops for use in layers and tf.learn."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import six
+
+from .. import contrib_framework
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import init_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import random_ops
+from tensorflow.python.ops import variable_scope as vs
+from tensorflow.python.ops import variables as vars_
+from tensorflow.python.summary import summary
+from tensorflow.python.training import moving_averages
+from tensorflow.python.training import optimizer as optimizer_
+from tensorflow.python.training import training as train
+
+OPTIMIZER_CLS_NAMES = {
+    "Adagrad": train.AdagradOptimizer,
+    "Adam": train.AdamOptimizer,
+    "Ftrl": train.FtrlOptimizer,
+    "Momentum": lambda learning_rate: train.MomentumOptimizer(learning_rate, momentum=0.9),  # pylint: disable=line-too-long
+    "RMSProp": train.RMSPropOptimizer,
+    "SGD": train.GradientDescentOptimizer,
+}
+
+OPTIMIZER_SUMMARIES = [
+    "learning_rate",
+    "loss",
+    "gradients",
+    "gradient_norm",
+    "global_gradient_norm",
+]
+
+
+def optimize_loss(loss,
+                  global_step,
+                  learning_rate,
+                  optimizer,
+                  gradient_noise_scale=None,
+                  gradient_multipliers=None,
+                  clip_gradients=None,
+                  learning_rate_decay_fn=None,
+                  update_ops=None,
+                  variables=None,
+                  name=None,
+                  summaries=None,
+                  colocate_gradients_with_ops=False,
+                  increment_global_step=True):
+  """Given loss and parameters for optimizer, returns a training op.
+
+  Various ways of passing optimizers include:
+
+  - by string specifying the name of the optimizer. See OPTIMIZER_CLS_NAMES
+      for full list. E.g. `optimize_loss(..., optimizer='Adam')`.
+  - by function taking learning rate `Tensor` as argument and returning an
+      `Optimizer` instance. E.g. `optimize_loss(...,
+      optimizer=lambda lr: tf.compat.v1.train.MomentumOptimizer(lr,
+      momentum=0.5))`.
+    Alternatively, if `learning_rate` is `None`, the function takes no
+    arguments. E.g. `optimize_loss(..., learning_rate=None,
+      optimizer=lambda: tf.compat.v1.train.MomentumOptimizer(0.5,
+      momentum=0.5))`.
+  - by a subclass of `Optimizer` having a single-argument constructor
+      (the argument is the learning rate), such as AdamOptimizer or
+      AdagradOptimizer. E.g. `optimize_loss(...,
+      optimizer=tf.compat.v1.train.AdagradOptimizer)`.
+  - by an instance of a subclass of `Optimizer`.
+      E.g., `optimize_loss(...,
+      optimizer=tf.compat.v1.train.AdagradOptimizer(0.5))`.
+
+  Args:
+    loss: Scalar `Tensor`.
+    global_step: Scalar int `Tensor`, step counter to update on each step unless
+      `increment_global_step` is `False`. If not supplied, it will be fetched
+      from the default graph (see `tf.compat.v1.train.get_global_step` for
+      details). If it has not been created, no step will be incremented with
+      each weight update. `learning_rate_decay_fn` requires `global_step`.
+    learning_rate: float or `Tensor`, magnitude of update per each training
+      step. Can be `None`.
+    optimizer: string, class or optimizer instance, used as trainer. string
+      should be name of optimizer, like 'SGD', 'Adam', 'Adagrad'. Full list in
+      OPTIMIZER_CLS_NAMES constant. class should be sub-class of `tf.Optimizer`
+      that implements `compute_gradients` and `apply_gradients` functions.
+      optimizer instance should be instantiation of `tf.Optimizer` sub-class and
+      have `compute_gradients` and `apply_gradients` functions.
+    gradient_noise_scale: float or None, adds 0-mean normal noise scaled by this
+      value.
+    gradient_multipliers: dict of variables or variable names to floats. If
+      present, gradients for specified variables will be multiplied by given
+      constant.
+    clip_gradients: float, callable or `None`. If a float is provided, a global
+      clipping is applied to prevent the norm of the gradient from exceeding
+      this value. Alternatively, a callable can be provided, e.g.,
+      `adaptive_clipping_fn()`.  This callable takes a list of `(gradients,
+      variables)` tuples and returns the same thing with the gradients modified.
+    learning_rate_decay_fn: function, takes `learning_rate` and `global_step`
+      `Tensor`s, returns `Tensor`. Can be used to implement any learning rate
+      decay functions.
+                            For example: `tf.compat.v1.train.exponential_decay`.
+                              Ignored if `learning_rate` is not supplied.
+    update_ops: list of update `Operation`s to execute at each step. If `None`,
+      uses elements of UPDATE_OPS collection. The order of execution between
+      `update_ops` and `loss` is non-deterministic.
+    variables: list of variables to optimize or `None` to use all trainable
+      variables.
+    name: The name for this operation is used to scope operations and summaries.
+    summaries: List of internal quantities to visualize on tensorboard. If not
+      set, the loss, the learning rate, and the global norm of the gradients
+      will be reported. The complete list of possible values is in
+      OPTIMIZER_SUMMARIES.
+    colocate_gradients_with_ops: If True, try colocating gradients with the
+      corresponding op.
+    increment_global_step: Whether to increment `global_step`. If your model
+      calls `optimize_loss` multiple times per training step (e.g. to optimize
+      different parts of the model), use this arg to avoid incrementing
+      `global_step` more times than necessary.
+
+  Returns:
+    Training op.
+
+  Raises:
+    ValueError: if:
+        * `loss` is an invalid type or shape.
+        * `global_step` is an invalid type or shape.
+        * `learning_rate` is an invalid type or value.
+        * `optimizer` has the wrong type.
+        * `clip_gradients` is neither float nor callable.
+        * `learning_rate` and `learning_rate_decay_fn` are supplied, but no
+          `global_step` is available.
+        * `gradients` is empty.
+  """
+  loss = ops.convert_to_tensor(loss)
+  contrib_framework.assert_scalar(loss)
+  if global_step is None:
+    global_step = train.get_global_step()
+  else:
+    train.assert_global_step(global_step)
+  with vs.variable_scope(name, "OptimizeLoss", [loss, global_step]):
+    # Update ops take UPDATE_OPS collection if not provided.
+    if update_ops is None:
+      update_ops = set(ops.get_collection(ops.GraphKeys.UPDATE_OPS))
+    # Make sure update ops are ran before computing loss.
+    if update_ops:
+      loss = control_flow_ops.with_dependencies(list(update_ops), loss)
+
+    # Learning rate variable, with possible decay.
+    lr = None
+    if learning_rate is not None:
+      if (isinstance(learning_rate, ops.Tensor) and
+          learning_rate.get_shape().ndims == 0):
+        lr = learning_rate
+      elif isinstance(learning_rate, float):
+        if learning_rate < 0.0:
+          raise ValueError("Invalid learning_rate %s.", learning_rate)
+        lr = vs.get_variable(
+            "learning_rate", [],
+            trainable=False,
+            initializer=init_ops.constant_initializer(learning_rate))
+      else:
+        raise ValueError("Learning rate should be 0d Tensor or float. "
+                         "Got %s of type %s" %
+                         (str(learning_rate), str(type(learning_rate))))
+    if summaries is None:
+      summaries = ["loss", "learning_rate", "global_gradient_norm"]
+    else:
+      for summ in summaries:
+        if summ not in OPTIMIZER_SUMMARIES:
+          raise ValueError("Summaries should be one of [%s], you provided %s." %
+                           (", ".join(OPTIMIZER_SUMMARIES), summ))
+    if learning_rate is not None and learning_rate_decay_fn is not None:
+      if global_step is None:
+        raise ValueError("global_step is required for learning_rate_decay_fn.")
+      lr = learning_rate_decay_fn(lr, global_step)
+      if "learning_rate" in summaries:
+        summary.scalar("learning_rate", lr)
+
+    # Create optimizer, given specified parameters.
+    if isinstance(optimizer, six.string_types):
+      if lr is None:
+        raise ValueError("Learning rate is None, but should be specified if "
+                         "optimizer is string (%s)." % optimizer)
+      if optimizer not in OPTIMIZER_CLS_NAMES:
+        raise ValueError(
+            "Optimizer name should be one of [%s], you provided %s." %
+            (", ".join(OPTIMIZER_CLS_NAMES), optimizer))
+      opt = OPTIMIZER_CLS_NAMES[optimizer](learning_rate=lr)
+    elif (isinstance(optimizer, type) and
+          issubclass(optimizer, optimizer_.Optimizer)):
+      if lr is None:
+        raise ValueError("Learning rate is None, but should be specified if "
+                         "optimizer is class (%s)." % optimizer)
+      opt = optimizer(learning_rate=lr)
+    elif isinstance(optimizer, optimizer_.Optimizer):
+      opt = optimizer
+    elif callable(optimizer):
+      if learning_rate is not None:
+        opt = optimizer(lr)
+      else:
+        opt = optimizer()
+      if not isinstance(opt, optimizer_.Optimizer):
+        raise ValueError("Unrecognized optimizer: function should return "
+                         "subclass of Optimizer. Got %s." % str(opt))
+    else:
+      raise ValueError("Unrecognized optimizer: should be string, "
+                       "subclass of Optimizer, instance of "
+                       "subclass of Optimizer or function with one argument. "
+                       "Got %s." % str(optimizer))
+
+    # All trainable variables, if specific variables are not specified.
+    if variables is None:
+      variables = vars_.trainable_variables()
+
+    # Compute gradients.
+    gradients = opt.compute_gradients(
+        loss,
+        variables,
+        colocate_gradients_with_ops=colocate_gradients_with_ops)
+
+    # Optionally add gradient noise.
+    if gradient_noise_scale is not None:
+      gradients = _add_scaled_noise_to_gradients(gradients,
+                                                 gradient_noise_scale)
+
+    # Multiply some gradients.
+    if gradient_multipliers is not None:
+      gradients = _multiply_gradients(gradients, gradient_multipliers)
+      if not gradients:
+        raise ValueError(
+            "Empty list of (gradient, var) pairs encountered. This is most "
+            "likely to be caused by an improper value of gradient_multipliers.")
+
+    if "global_gradient_norm" in summaries or "gradient_norm" in summaries:
+      summary.scalar("global_norm/gradient_norm",
+                     clip_ops.global_norm(list(zip(*gradients))[0]))
+
+    # Optionally clip gradients by global norm.
+    if isinstance(clip_gradients, float):
+      gradients = _clip_gradients_by_norm(gradients, clip_gradients)
+    elif callable(clip_gradients):
+      gradients = clip_gradients(gradients)
+    elif clip_gradients is not None:
+      raise ValueError("Unknown type %s for clip_gradients" %
+                       type(clip_gradients))
+
+    # Add scalar summary for loss.
+    if "loss" in summaries:
+      summary.scalar("loss", loss)
+
+    # Add histograms for variables, gradients and gradient norms.
+    for gradient, variable in gradients:
+      if isinstance(gradient, ops.IndexedSlices):
+        grad_values = gradient.values
+      else:
+        grad_values = gradient
+
+      if grad_values is not None:
+        var_name = variable.name.replace(":", "_")
+        if "gradients" in summaries:
+          summary.histogram("gradients/%s" % var_name, grad_values)
+        if "gradient_norm" in summaries:
+          summary.scalar("gradient_norm/%s" % var_name,
+                         clip_ops.global_norm([grad_values]))
+
+    if clip_gradients is not None and ("global_gradient_norm" in summaries or
+                                       "gradient_norm" in summaries):
+      summary.scalar("global_norm/clipped_gradient_norm",
+                     clip_ops.global_norm(list(zip(*gradients))[0]))
+
+    # Create gradient updates.
+    grad_updates = opt.apply_gradients(
+        gradients,
+        global_step=global_step if increment_global_step else None,
+        name="train")
+
+    # Ensure the train_tensor computes grad_updates.
+    train_tensor = control_flow_ops.with_dependencies([grad_updates], loss)
+
+    return train_tensor
+
+
+def _clip_gradients_by_norm(grads_and_vars, clip_gradients):
+  """Clips gradients by global norm."""
+  gradients, variables = zip(*grads_and_vars)
+  clipped_gradients, _ = clip_ops.clip_by_global_norm(gradients, clip_gradients)
+  return list(zip(clipped_gradients, variables))
+
+
+def _adaptive_max_norm(norm, std_factor, decay, global_step, epsilon, name):
+  """Find max_norm given norm and previous average."""
+  with vs.variable_scope(name, "AdaptiveMaxNorm", [norm]):
+    log_norm = math_ops.log(norm + epsilon)
+
+    def moving_average(name, value, decay):
+      moving_average_variable = vs.get_variable(
+          name,
+          shape=value.get_shape(),
+          dtype=value.dtype,
+          initializer=init_ops.zeros_initializer(),
+          trainable=False)
+      return moving_averages.assign_moving_average(
+          moving_average_variable, value, decay, zero_debias=False)
+
+    # quicker adaptation at the beginning
+    if global_step is not None:
+      n = math_ops.cast(global_step, dtypes.float32)
+      decay = math_ops.minimum(decay, n / (n + 1.))
+
+    # update averages
+    mean = moving_average("mean", log_norm, decay)
+    sq_mean = moving_average("sq_mean", math_ops.square(log_norm), decay)
+
+    variance = sq_mean - math_ops.square(mean)
+    std = math_ops.sqrt(math_ops.maximum(epsilon, variance))
+    max_norms = math_ops.exp(mean + std_factor * std)
+    return max_norms, mean
+
+
+def adaptive_clipping_fn(std_factor=2.,
+                         decay=0.95,
+                         static_max_norm=None,
+                         global_step=None,
+                         report_summary=False,
+                         epsilon=1e-8,
+                         name=None):
+  """Adapt the clipping value using statistics on the norms.
+
+  Implement adaptive gradient as presented in section 3.2.1 of
+  https://arxiv.org/abs/1412.1602.
+
+  Keeps a moving average of the mean and std of the log(norm) of the gradient.
+  If the norm exceeds `exp(mean + std_factor*std)` then all gradients will be
+  rescaled such that the global norm becomes `exp(mean)`.
+
+  Args:
+    std_factor: Python scaler (or tensor). `max_norm = exp(mean +
+      std_factor*std)`
+    decay: The smoothing factor of the moving averages.
+    static_max_norm: If provided, will threshold the norm to this value as an
+      extra safety.
+    global_step: Optional global_step. If provided, `decay = decay*n/(n+1)`.
+      This provides a quicker adaptation of the mean for the first steps.
+    report_summary: If `True`, will add histogram summaries of the `max_norm`.
+    epsilon: Small value chosen to avoid zero variance.
+    name: The name for this operation is used to scope operations and summaries.
+
+  Returns:
+    A function for applying gradient clipping.
+  """
+
+  def gradient_clipping(grads_and_vars):
+    """Internal function for adaptive clipping."""
+    grads, variables = zip(*grads_and_vars)
+
+    norm = clip_ops.global_norm(grads)
+
+    max_norm, log_mean = _adaptive_max_norm(norm, std_factor, decay,
+                                            global_step, epsilon, name)
+
+    # reports the max gradient norm for debugging
+    if report_summary:
+      summary.scalar("global_norm/adaptive_max_gradient_norm", max_norm)
+
+    # factor will be 1. if norm is smaller than max_norm
+    factor = array_ops.where(norm < max_norm, array_ops.ones_like(norm),
+                             math_ops.exp(log_mean) / norm)
+
+    if static_max_norm is not None:
+      factor = math_ops.minimum(static_max_norm / norm, factor)
+
+    # apply factor
+    clipped_grads = []
+    for grad in grads:
+      if grad is None:
+        clipped_grads.append(None)
+      elif isinstance(grad, ops.IndexedSlices):
+        clipped_grads.append(
+            ops.IndexedSlices(grad.values * factor, grad.indices,
+                              grad.dense_shape))
+      else:
+        clipped_grads.append(grad * factor)
+
+    return list(zip(clipped_grads, variables))
+
+  return gradient_clipping
+
+
+def _add_scaled_noise_to_gradients(grads_and_vars, gradient_noise_scale):
+  """Adds scaled noise from a 0-mean normal distribution to gradients."""
+  gradients, variables = zip(*grads_and_vars)
+  noisy_gradients = []
+  for gradient in gradients:
+    if gradient is None:
+      noisy_gradients.append(None)
+      continue
+    if isinstance(gradient, ops.IndexedSlices):
+      gradient_shape = gradient.dense_shape
+    else:
+      gradient_shape = gradient.get_shape()
+    noise = random_ops.truncated_normal(gradient_shape) * gradient_noise_scale
+    noisy_gradients.append(gradient + noise)
+  return list(zip(noisy_gradients, variables))
+
+
+def _multiply_gradients(grads_and_vars, gradient_multipliers):
+  """Multiply specified gradients."""
+  multiplied_grads_and_vars = []
+  for grad, var in grads_and_vars:
+    if (grad is not None and
+        (var in gradient_multipliers or var.name in gradient_multipliers)):
+      key = var if var in gradient_multipliers else var.name
+      multiplier = gradient_multipliers[key]
+      if isinstance(grad, ops.IndexedSlices):
+        grad_values = grad.values * multiplier
+        grad = ops.IndexedSlices(grad_values, grad.indices, grad.dense_shape)
+      else:
+        grad *= math_ops.cast(multiplier, grad.dtype)
+    multiplied_grads_and_vars.append((grad, var))
+  return multiplied_grads_and_vars

--- a/tensornets/contrib_layers/regularizers.py
+++ b/tensornets/contrib_layers/regularizers.py
@@ -1,0 +1,209 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Regularizers for use with layers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numbers
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn
+from tensorflow.python.ops import standard_ops
+from tensorflow.python.platform import tf_logging as logging
+
+__all__ = ['l1_regularizer',
+           'l2_regularizer',
+           'l1_l2_regularizer',
+           'sum_regularizer',
+           'apply_regularization']
+
+
+def l1_regularizer(scale, scope=None):
+  """Returns a function that can be used to apply L1 regularization to weights.
+
+  L1 regularization encourages sparsity.
+
+  Args:
+    scale: A scalar multiplier `Tensor`. 0.0 disables the regularizer.
+    scope: An optional scope name.
+
+  Returns:
+    A function with signature `l1(weights)` that apply L1 regularization.
+
+  Raises:
+    ValueError: If scale is negative or if scale is not a float.
+  """
+  if isinstance(scale, numbers.Integral):
+    raise ValueError('scale cannot be an integer: %s' % scale)
+  if isinstance(scale, numbers.Real):
+    if scale < 0.:
+      raise ValueError('Setting a scale less than 0 on a regularizer: %g' %
+                       scale)
+    if scale == 0.:
+      logging.info('Scale of 0 disables regularizer.')
+      return lambda _: None
+
+  def l1(weights, name=None):
+    """Applies L1 regularization to weights."""
+    with ops.name_scope(scope, 'l1_regularizer', [weights]) as name:
+      my_scale = ops.convert_to_tensor(scale,
+                                       dtype=weights.dtype.base_dtype,
+                                       name='scale')
+      return standard_ops.multiply(
+          my_scale,
+          standard_ops.reduce_sum(standard_ops.abs(weights)),
+          name=name)
+
+  return l1
+
+
+def l2_regularizer(scale, scope=None):
+  """Returns a function that can be used to apply L2 regularization to weights.
+
+  Small values of L2 can help prevent overfitting the training data.
+
+  Args:
+    scale: A scalar multiplier `Tensor`. 0.0 disables the regularizer.
+    scope: An optional scope name.
+
+  Returns:
+    A function with signature `l2(weights)` that applies L2 regularization.
+
+  Raises:
+    ValueError: If scale is negative or if scale is not a float.
+  """
+  if isinstance(scale, numbers.Integral):
+    raise ValueError('scale cannot be an integer: %s' % (scale,))
+  if isinstance(scale, numbers.Real):
+    if scale < 0.:
+      raise ValueError('Setting a scale less than 0 on a regularizer: %g.' %
+                       scale)
+    if scale == 0.:
+      logging.info('Scale of 0 disables regularizer.')
+      return lambda _: None
+
+  def l2(weights):
+    """Applies l2 regularization to weights."""
+    with ops.name_scope(scope, 'l2_regularizer', [weights]) as name:
+      my_scale = ops.convert_to_tensor(scale,
+                                       dtype=weights.dtype.base_dtype,
+                                       name='scale')
+      return standard_ops.multiply(my_scale, nn.l2_loss(weights), name=name)
+
+  return l2
+
+
+def l1_l2_regularizer(scale_l1=1.0, scale_l2=1.0, scope=None):
+  """Returns a function that can be used to apply L1 L2 regularizations.
+
+  Args:
+    scale_l1: A scalar multiplier `Tensor` for L1 regularization.
+    scale_l2: A scalar multiplier `Tensor` for L2 regularization.
+    scope: An optional scope name.
+
+  Returns:
+    A function with signature `l1_l2(weights)` that applies a weighted sum of
+    L1 L2 regularization.
+
+  Raises:
+    ValueError: If scale is negative or if scale is not a float.
+  """
+  if isinstance(scale_l1, numbers.Integral):
+    raise ValueError('scale_l1 cannot be an integer: %s' % (scale_l1,))
+  if isinstance(scale_l2, numbers.Integral):
+    raise ValueError('scale_l2 cannot be an integer: %s' % (scale_l2,))
+  scope = scope or 'l1_l2_regularizer'
+  if scale_l1 == 0.:
+    return l2_regularizer(scale_l2, scope)
+  if scale_l2 == 0.:
+    return l1_regularizer(scale_l1, scope)
+  return sum_regularizer([l1_regularizer(scale_l1),
+                          l2_regularizer(scale_l2)],
+                         scope=scope)
+
+
+def sum_regularizer(regularizer_list, scope=None):
+  """Returns a function that applies the sum of multiple regularizers.
+
+  Args:
+    regularizer_list: A list of regularizers to apply.
+    scope: An optional scope name
+
+  Returns:
+    A function with signature `sum_reg(weights)` that applies the
+    sum of all the input regularizers.
+  """
+  regularizer_list = [reg for reg in regularizer_list if reg is not None]
+  if not regularizer_list:
+    return None
+
+  def sum_reg(weights):
+    """Applies the sum of all the input regularizers."""
+    with ops.name_scope(scope, 'sum_regularizer', [weights]) as name:
+      regularizer_tensors = []
+      for reg in regularizer_list:
+        tensor = reg(weights)
+        if tensor is not None:
+          regularizer_tensors.append(tensor)
+      return math_ops.add_n(
+          regularizer_tensors, name=name) if regularizer_tensors else None
+
+  return sum_reg
+
+
+def apply_regularization(regularizer, weights_list=None):
+  """Returns the summed penalty by applying `regularizer` to the `weights_list`.
+
+  Adding a regularization penalty over the layer weights and embedding weights
+  can help prevent overfitting the training data. Regularization over layer
+  biases is less common/useful, but assuming proper data preprocessing/mean
+  subtraction, it usually shouldn't hurt much either.
+
+  Args:
+    regularizer: A function that takes a single `Tensor` argument and returns
+      a scalar `Tensor` output.
+    weights_list: List of weights `Tensors` or `Variables` to apply
+      `regularizer` over. Defaults to the `GraphKeys.WEIGHTS` collection if
+      `None`.
+
+  Returns:
+    A scalar representing the overall regularization penalty.
+
+  Raises:
+    ValueError: If `regularizer` does not return a scalar output, or if we find
+        no weights.
+  """
+  if not weights_list:
+    weights_list = ops.get_collection(ops.GraphKeys.WEIGHTS)
+  if not weights_list:
+    raise ValueError('No weights to regularize.')
+  with ops.name_scope('get_regularization_penalty',
+                      values=weights_list) as scope:
+    penalties = [regularizer(w) for w in weights_list]
+    penalties = [
+        p if p is not None else constant_op.constant(0.0) for p in penalties
+    ]
+    for p in penalties:
+      if p.get_shape().ndims != 0:
+        raise ValueError('regularizer must return a scalar Tensor instead of a '
+                         'Tensor with rank %d.' % p.get_shape().ndims)
+
+    summed_penalty = math_ops.add_n(penalties, name=scope)
+    ops.add_to_collection(ops.GraphKeys.REGULARIZATION_LOSSES, summed_penalty)
+    return summed_penalty

--- a/tensornets/contrib_layers/rev_block_lib.py
+++ b/tensornets/contrib_layers/rev_block_lib.py
@@ -1,0 +1,703 @@
+# Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Reversible Residual Block.
+
+From
+[The Reversible Residual Network: Backpropagation Without Storing
+Activations](https://arxiv.org/abs/1707.04585).
+
+Also contains the @recompute_grad decorator, which recomputes the forward
+function on the backwards pass.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import re
+
+import numpy as np
+import six
+from six.moves import xrange  # pylint: disable=redefined-builtin
+
+from .. import contrib_framework
+from tensorflow.python.eager import backprop
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops as framework_ops
+from tensorflow.python.layers import base
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import control_flow_util
+from tensorflow.python.ops import custom_gradient
+from tensorflow.python.ops import gradients_impl
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.ops import variables as variables_lib
+from tensorflow.python.platform import tf_logging as logging
+from tensorflow.python.util import nest
+from tensorflow.python.util import tf_inspect
+
+__all__ = ["rev_block", "RevBlock", "recompute_grad"]
+
+LAYER_RE = re.compile(".*revlayer_([0-9]*)/([fg])/.*")
+_USE_DEFAULT = "__rev_block_lib_default"
+_WRONG_VARS_ERR = """\
+The variables used on recompute were different than the variables originally
+used. The function wrapped with @recompute_grad likley creates its own variable
+scope with a default name and has been called twice in the same enclosing scope.
+To fix, ensure each call to the function happens in its own unique variable
+scope.
+"""
+
+
+def _acc_grads(*lists_of_grads):
+  """Accumulates lists of gradients."""
+  acc_grads = []
+  for grads in zip(*lists_of_grads):
+    grads = [g for g in grads if g is not None]
+    if grads:
+      acc_grads.append(math_ops.add_n(grads))
+    else:
+      acc_grads.append(None)
+  return acc_grads
+
+
+def _rev_layer_forward(xs, f, g, f_side_input, g_side_input,
+                       gate_outputs=False):
+  """Forward for 1 reversible layer."""
+  x1, x2 = xs
+  y1 = x1 + (f(x2, f_side_input) if f_side_input else f(x2))
+  y2 = x2 + (g(y1, g_side_input) if g_side_input else g(y1))
+  if gate_outputs:
+    return control_flow_ops.tuple([y1, y2])
+  else:
+    return (y1, y2)
+
+
+def _rev_layer_backward(ys, grad_ys, f, g, f_vars, f_side_input, g_vars,
+                        g_side_input):
+  """Backprop for 1 layer."""
+  y1, y2 = ys
+  grad_y1, grad_y2 = grad_ys
+
+  # Reconstruct intermediates and inputs (x1, x2)
+  # stop_gradients required on fn inputs to prevent infinite recursion into this
+  # grad function on the calls to gradients.
+  y1_stop = array_ops.stop_gradient(y1)
+  g_side_input = [array_ops.stop_gradient(t) for t in g_side_input]
+  gy1 = g(y1_stop, g_side_input) if g_side_input else g(y1_stop)
+
+  x2 = y2 - gy1
+  x2_stop = array_ops.stop_gradient(x2)
+  f_side_input = [array_ops.stop_gradient(t) for t in f_side_input]
+  fx2 = f(x2_stop, f_side_input) if f_side_input else f(x2_stop)
+
+  x1 = y1 - fx2
+
+  # Compute gradients wrt to inputs
+  # dL/dy2 * dG(y1)/y1
+  grad_gy1_y2 = gradients_impl.gradients(gy1, y1_stop, grad_y2)[0]
+  grad_x1 = grad_y1 + grad_gy1_y2
+  grad_x2 = (
+      gradients_impl.gradients(fx2, x2_stop, grad_y1)[0] + grad_y2 +
+      gradients_impl.gradients(fx2, x2_stop, grad_gy1_y2)[0])
+
+  # Compute gradients wrt to vars and side inputs in f and g
+  grads1 = gradients_impl.gradients(gy1, g_vars + g_side_input, grad_y2)
+  grad_g_vars, grad_g_side = grads1[:len(g_vars)], grads1[len(g_vars):]
+  grads2 = gradients_impl.gradients(fx2, f_vars + f_side_input, grad_y1)
+  grad_f_y1, grad_f_side1 = grads2[:len(f_vars)], grads2[len(f_vars):]
+  grads3 = gradients_impl.gradients(fx2, f_vars + f_side_input, grad_gy1_y2)
+  grad_f_y2, grad_f_side2 = grads3[:len(f_vars)], grads3[len(f_vars):]
+  grad_f_vars = _acc_grads(grad_f_y1, grad_f_y2)
+
+  grad_f_side = _acc_grads(grad_f_side1, grad_f_side2)
+
+  # Put returns in a tuple to ensure a constant memory budget (i.e. don't want
+  # the subsequent layer to start computing and consuming memory based on a
+  # subset of these values).
+  outputs = ((x1, x2), (grad_x1, grad_x2), (grad_f_vars, grad_f_side),
+             (grad_g_vars, grad_g_side))
+  tupled = control_flow_ops.tuple(nest.flatten(outputs))
+  return nest.pack_sequence_as(outputs, tupled)
+
+
+def _rev_block_forward(x1,
+                       x2,
+                       f,
+                       g,
+                       num_layers=1,
+                       f_side_input=None,
+                       g_side_input=None,
+                       gate_outputs=False):
+  """Forward for a series of reversible layers."""
+  out = (x1, x2)
+  for i in xrange(num_layers):
+    out = _rev_layer_forward(
+        out, f[i], g[i], f_side_input, g_side_input, gate_outputs=gate_outputs)
+
+  y1, y2 = out
+  return y1, y2
+
+
+def _safe_wraps(fn):
+  if isinstance(fn, functools.partial):
+    # functools.partial objects cannot be wrapped as they are missing the
+    # necessary properties (__name__, __module__, __doc__).
+    def passthrough(f):
+      return f
+    return passthrough
+  return functools.wraps(fn)
+
+
+def _scope_wrap(fn, scope):
+
+  @_safe_wraps(fn)
+  def wrap(*args, **kwargs):
+    with variable_scope.variable_scope(scope, use_resource=True):
+      return fn(*args, **kwargs)
+
+  return wrap
+
+
+class RevBlock(base.Layer):
+  """Block of reversible layers. See rev_block."""
+
+  def __init__(self,
+               f,
+               g,
+               num_layers=1,
+               f_side_input=None,
+               g_side_input=None,
+               use_efficient_backprop=True,
+               name="revblock",
+               **kwargs):
+    super(RevBlock, self).__init__(name=name, **kwargs)
+
+    if isinstance(f, list):
+      assert len(f) == num_layers
+    else:
+      f = [f] * num_layers
+
+    if isinstance(g, list):
+      assert len(g) == num_layers
+    else:
+      g = [g] * num_layers
+
+    f = [_scope_wrap(fn, "revlayer_%d/f" % i) for i, fn in enumerate(f)]
+    g = [_scope_wrap(fn, "revlayer_%d/g" % i) for i, fn in enumerate(g)]
+
+    self.f = f
+    self.g = g
+
+    self.num_layers = num_layers
+    self.f_side_input = f_side_input or []
+    self.g_side_input = g_side_input or []
+
+    self._use_efficient_backprop = use_efficient_backprop
+
+  def call(self, inputs, forward=True):
+    vs = variable_scope.get_variable_scope()
+    vars_before = vs.global_variables()
+
+    if forward:
+      x1, x2 = inputs
+      out = self._forward(x1, x2)
+    else:
+      y1, y2 = inputs
+      out = self._backward(y1, y2)
+
+    # Add any created variables to the Layer's variable stores
+    new_vars = vs.global_variables()[len(vars_before):]
+    train_vars = vs.trainable_variables()
+    for new_var in new_vars:
+      if new_var in train_vars:
+        self._trainable_weights.append(new_var)
+      else:
+        self._non_trainable_weights.append(new_var)
+
+    return out
+
+  def forward(self, x1, x2):
+    return self.apply([x1, x2])
+
+  def backward(self, y1, y2):
+    return self.apply([y1, y2], forward=False)
+
+  def build(self, _):
+    logging.warn("RevBlock constructs its variables on first call, not on "
+                 "build.")
+    self.built = True
+
+  def _make_efficient_grad_fn(self, inputs_, ys_):
+    def _efficient_grad_fn(*grad_ys, **kwargs):
+      """Custom gradient fn for a block of reversible residual layers."""
+      inputs = inputs_
+      ys = ys_
+      variables = kwargs["variables"]
+      side_inputs = inputs[2:]
+
+      f_side_idxs = [None] * len(self.f_side_input)
+      g_side_idxs = [None] * len(self.g_side_input)
+      assert len(side_inputs) == len(self.f_side_input) + len(self.g_side_input)
+
+      for i, t in enumerate(side_inputs):
+        if t in self.f_side_input:
+          f_side_idxs[self.f_side_input.index(t)] = i
+        elif t in self.g_side_input:
+          g_side_idxs[self.g_side_input.index(t)] = i
+        else:
+          assert False
+
+      f_vars = [[] for _ in range(self.num_layers)]
+      g_vars = [[] for _ in range(self.num_layers)]
+      f_vars_idxs = [[] for _ in range(self.num_layers)]
+      g_vars_idxs = [[] for _ in range(self.num_layers)]
+
+      for i, ref in enumerate(variables):
+        # Use the name to identify the layer number and function (f or g)
+        regex = LAYER_RE.match(ref.name)
+        layer_no = int(regex.group(1))
+        fn_name = regex.group(2)
+        if fn_name == "f":
+          f_vars[layer_no].append(ref)
+          f_vars_idxs[layer_no].append(i)
+        else:
+          assert fn_name == "g"
+          g_vars[layer_no].append(ref)
+          g_vars_idxs[layer_no].append(i)
+
+      f_var_grads = []
+      g_var_grads = []
+      f_side_grads = []
+      g_side_grads = []
+
+      # Reverse variable containers to go backward
+      f_vars.reverse()
+      g_vars.reverse()
+      f = list(self.f)
+      g = list(self.g)
+      f.reverse()
+      g.reverse()
+
+      with variable_scope.variable_scope(self.scope_name, reuse=True):
+        for i in xrange(self.num_layers):
+          ys, grad_ys, f_ret, g_ret = _rev_layer_backward(
+              ys, grad_ys, f[i], g[i], f_vars[i], self.f_side_input, g_vars[i],
+              self.g_side_input)
+
+          grad_f_vars, grad_f_side = f_ret
+          grad_g_vars, grad_g_side = g_ret
+          f_var_grads.append(grad_f_vars)
+          g_var_grads.append(grad_g_vars)
+          f_side_grads.append(grad_f_side)
+          g_side_grads.append(grad_g_side)
+
+      # Accumulate layer gradients for f_side_input and g_side_input
+      acc_f_side_grads = _acc_grads(*f_side_grads)
+      acc_g_side_grads = _acc_grads(*g_side_grads)
+
+      # Use the stored idxs to put gradients in the passed-in order.
+      side_input_grads = [None] * len(side_inputs)
+      variable_grads = [None] * len(variables)
+
+      # Variable gradients were collected in reverse layer order. Reverse to
+      # match idxs.
+      f_var_grads.reverse()
+      g_var_grads.reverse()
+      for idxs, grads in list(zip(f_vars_idxs, f_var_grads)) + list(
+          zip(g_vars_idxs, g_var_grads)):
+        for i, grad in zip(idxs, grads):
+          variable_grads[i] = grad
+
+      for i, grad in zip(f_side_idxs, acc_f_side_grads):
+        side_input_grads[i] = grad
+      for i, grad in zip(g_side_idxs, acc_g_side_grads):
+        side_input_grads[i] = grad
+
+      grad_x1, grad_x2 = grad_ys
+      return [grad_x1, grad_x2] + side_input_grads, variable_grads
+    return _efficient_grad_fn
+
+  def _forward(self, x1, x2):
+    """Run forward through the reversible layers."""
+
+    side_inputs = [self.f_side_input, self.g_side_input]
+    flat_side_inputs = nest.flatten(side_inputs)
+
+    def _forward_wrap(x1_, x2_, *flat_side_inputs):
+      f_side, g_side = nest.pack_sequence_as(side_inputs, flat_side_inputs)
+      return _rev_block_forward(
+          x1_,
+          x2_,
+          self.f,
+          self.g,
+          num_layers=self.num_layers,
+          f_side_input=f_side,
+          g_side_input=g_side,
+          gate_outputs=self._use_efficient_backprop)
+
+    @custom_gradient.custom_gradient
+    def _forward_with_custom_grad(*args):
+      out = _forward_wrap(*args)  # pylint: disable=no-value-for-parameter
+      grad_fn = self._make_efficient_grad_fn(args, out)
+      return out, grad_fn
+
+    if self._use_efficient_backprop:
+      return _forward_with_custom_grad(x1, x2, *flat_side_inputs)
+    else:
+      return _forward_wrap(x1, x2, *flat_side_inputs)
+
+  def _backward(self, y1, y2):
+    """Run backward through the reversible layers."""
+
+    f = list(self.f)
+    g = list(self.g)
+    f.reverse()
+    g.reverse()
+
+    for i in xrange(self.num_layers):
+      gy1 = g[i](y1, self.g_side_input) if self.g_side_input else g[i](y1)
+      x2 = y2 - gy1
+      fx2 = f[i](x2, self.f_side_input) if self.f_side_input else f[i](x2)
+      x1 = y1 - fx2
+
+      y1, y2 = x1, x2
+
+    return x1, x2
+
+
+def rev_block(x1,
+              x2,
+              f,
+              g,
+              num_layers=1,
+              f_side_input=None,
+              g_side_input=None,
+              is_training=True):
+  """A block of reversible residual layers.
+
+  A reversible residual layer is defined as:
+
+  ```
+  y1 = x1 + f(x2, f_side_input)
+  y2 = x2 + g(y1, g_side_input)
+  ```
+
+  A reversible residual block, defined here, is a series of reversible residual
+  layers.
+
+  Limitations:
+  * f and g must not close over any Tensors; all side inputs to f and g should
+    be passed in with f_side_input and g_side_input which will be forwarded to
+    f and g.
+  * f and g must not change the dimensionality of their inputs in order for the
+    addition in the equations above to work.
+
+  Args:
+    x1: a float Tensor.
+    x2: a float Tensor.
+    f: a function, (Tensor) -> (Tensor) (or list of such of length num_layers).
+      Should not change the shape of the Tensor. Can make calls to get_variable.
+      See f_side_input if there are side inputs.
+    g: a function, (Tensor) -> (Tensor) (or list of such of length num_layers).
+      Should not change the shape of the Tensor. Can make calls to get_variable.
+      See g_side_input if there are side inputs.
+    num_layers: int, number of reversible residual layers. Each layer will
+      apply f and g according to the equations above, with new variables in each
+      layer.
+    f_side_input: list of Tensors, side input to f. If not None, signature of f
+      should be (Tensor, list<Tensor>) -> (Tensor).
+    g_side_input: list of Tensors, side input to g. If not None, signature of g
+      should be (Tensor, list<Tensor>) -> (Tensor).
+    is_training: bool, whether to actually use the efficient backprop codepath.
+
+  Returns:
+    y1, y2: tuple of float Tensors.
+  """
+  block = RevBlock(
+      f=f,
+      g=g,
+      num_layers=num_layers,
+      f_side_input=f_side_input,
+      g_side_input=g_side_input,
+      use_efficient_backprop=is_training,
+      _reuse=variable_scope.get_variable_scope().reuse)
+  return block.forward(x1, x2)
+
+
+def enable_with_args(dec):
+  """A decorator for decorators to enable their usage with or without args."""
+
+  @_safe_wraps(dec)
+  def new_dec(*args, **kwargs):
+    if len(args) == 1 and not kwargs and callable(args[0]):
+      # Used as decorator without args
+      fn = args[0]
+      return dec(fn)
+    else:
+      return lambda fn: dec(fn, *args, **kwargs)
+
+  return new_dec
+
+
+@enable_with_args
+def recompute_grad(fn, use_data_dep=_USE_DEFAULT, tupleize_grads=False):
+  """Decorator that recomputes the function on the backwards pass.
+
+  To use this function, you must use `ResourceVariable`s (i.e.
+  `variable_scope(name, use_resource=True), which are the default in Eager mode
+  and when running on TPU.
+
+  Warning: Because the function will be called again on the backwards pass, the
+  user should be careful to not use ops in their function that mutate state or
+  have randomness (for example, batch normalization or dropout). If the function
+  does have such operations, it is recommended that the function take the
+  `is_recomputing` keyword argument which will be `False` on the forward pass
+  and `True` on the backwards pass so that it can disable state changes when
+  `is_recomputing=True` (for example, not updating the moving averages in batch
+  normalization).
+
+  Args:
+    fn: a function that takes Tensors (all as positional arguments) and returns
+      a tuple of Tensors. Note that `fn` should not close over any other
+      Tensors or Variables.
+    use_data_dep: `bool`, if `True` will use a dummy data dependency to force
+      the recompute to happen. If `False` will use a control dependency. By
+      default will be `True` if in an XLA context and `False` otherwise. XLA
+      ignores control dependencies and so this data dependency is necessary.
+    tupleize_grads: `bool`, if `True` will use control dependencies to ensure
+      that all gradients are produced before any are consumed by downstream ops.
+      If `use_data_dep` is also `True`, will use a data dependency instead of
+      a control dependency.
+
+  Returns:
+    A wrapped fn that is identical to fn when called, but its activations will
+    be discarded and recomputed on the backwards pass (i.e. on a call to
+    tf.gradients).
+
+  Raises:
+    ValueError: if `fn` closes over any Tensors or Variables.
+  """
+  # Check for closed-over Tensors/Variables
+  if fn.__code__.co_freevars:
+    closed_over_vars = dict(zip(fn.__code__.co_freevars,
+                                [c.cell_contents for c in fn.__closure__]))
+    for var_name, value in six.iteritems(closed_over_vars):
+      if isinstance(value, (framework_ops.Tensor, variables_lib.Variable)):
+        raise ValueError(
+            "fn decorated with @recompute_grad closes over Tensor %s "
+            "(local variable name: %s). The decorated fn must not close over "
+            "Tensors or Variables because gradients will NOT be computed for "
+            "them through fn. To ensure correct gradients, make the "
+            "Tensor an input to fn." % (value.name, var_name))
+
+  @_safe_wraps(fn)
+  def wrapped(*args):
+    return _recompute_grad(
+        fn, args, use_data_dep=use_data_dep, tupleize_grads=tupleize_grads)
+
+  return wrapped
+
+
+def _is_on_tpu():
+  ctxt = framework_ops.get_default_graph()._get_control_flow_context()  # pylint: disable=protected-access
+  return control_flow_util.GetContainingXLAContext(ctxt) is not None
+
+
+def _recomputing_grad_fn(compute_fn,
+                         original_args,
+                         original_vars,
+                         output_grads,
+                         grad_fn_variables,
+                         use_data_dep,
+                         tupleize_grads,
+                         arg_scope,
+                         var_scope,
+                         has_is_recompute_kwarg):
+  """Grad fn for recompute_grad."""
+  variables = grad_fn_variables or []
+
+  # Identity ops around the inputs ensures correct gradient graph-walking.
+  inputs = [array_ops.identity(x) for x in list(original_args)]
+
+  # Recompute outputs
+  # Use a control dependency to ensure that the recompute is not eliminated by
+  # CSE and that it happens on the backwards pass.
+  ctrl_dep_grads = [g for g in output_grads if g is not None]
+  with framework_ops.control_dependencies(ctrl_dep_grads):
+    if use_data_dep:
+      inputs = _force_data_dependency(output_grads, inputs)
+    # Re-enter scopes
+    with contrib_framework_ops.arg_scope(arg_scope):
+      with variable_scope.variable_scope(var_scope, reuse=True):
+        # Re-call the function and ensure that the touched variables are the
+        # same as in the first call.
+        with backprop.GradientTape() as tape:
+          fn_kwargs = {}
+          if has_is_recompute_kwarg:
+            fn_kwargs["is_recomputing"] = True
+          outputs = compute_fn(*inputs, **fn_kwargs)
+        recompute_vars = set(tape.watched_variables())
+        if original_vars != recompute_vars:
+          raise ValueError(_WRONG_VARS_ERR)
+
+  if not isinstance(outputs, (list, tuple)):
+    outputs = [outputs]
+  outputs = list(outputs)
+
+  # Compute gradients
+  grads = gradients_impl.gradients(outputs, inputs + variables,
+                                   output_grads)
+
+  if tupleize_grads:
+    if use_data_dep:
+      grads = _tuple_with_data_dep(grads)
+    else:
+      grads = control_flow_ops.tuple(grads)
+
+  grad_inputs = grads[:len(inputs)]
+  grad_vars = grads[len(inputs):]
+  return grad_inputs, grad_vars
+
+
+def _recompute_grad(fn, args, use_data_dep=_USE_DEFAULT, tupleize_grads=False):
+  """See recompute_grad."""
+  has_is_recompute_kwarg = "is_recomputing" in tf_inspect.getargspec(fn).args
+  for arg in args:
+    if not isinstance(arg, framework_ops.Tensor):
+      raise ValueError("All inputs to function must be Tensors")
+  use_data_dep_ = use_data_dep
+  if use_data_dep_ == _USE_DEFAULT:
+    use_data_dep_ = _is_on_tpu()
+
+  # Use custom_gradient and return a grad_fn that recomputes on the backwards
+  # pass.
+  @custom_gradient.custom_gradient
+  def fn_with_recompute(*args):
+    """Wrapper for fn."""
+    # Capture the variable and arg scopes so we can re-enter them when
+    # recomputing.
+    vs = variable_scope.get_variable_scope()
+    arg_scope = contrib_framework_ops.current_arg_scope()
+    # Track all variables touched in the function.
+    with backprop.GradientTape() as tape:
+      fn_kwargs = {}
+      if has_is_recompute_kwarg:
+        fn_kwargs["is_recomputing"] = False
+      outputs = fn(*args, **fn_kwargs)
+    original_vars = set(tape.watched_variables())
+
+    def _grad_fn(output_grads, variables=None):
+      # Validate that custom_gradient passes the right variables into grad_fn.
+      if original_vars:
+        assert variables, ("Fn created variables but the variables were not "
+                           "passed to the gradient fn.")
+        if set(variables) != original_vars:
+          raise ValueError(_WRONG_VARS_ERR)
+
+      return _recomputing_grad_fn(
+          compute_fn=fn,
+          original_args=args,
+          original_vars=original_vars,
+          output_grads=output_grads,
+          grad_fn_variables=variables,
+          use_data_dep=use_data_dep_,
+          tupleize_grads=tupleize_grads,
+          arg_scope=arg_scope,
+          var_scope=vs,
+          has_is_recompute_kwarg=has_is_recompute_kwarg)
+
+    # custom_gradient inspects the signature of the function to determine
+    # whether the user expects variables passed in the grad_fn. If the function
+    # created variables, the grad_fn should accept the "variables" kwarg.
+    if original_vars:
+      def grad_fn(*output_grads, **kwargs):
+        return _grad_fn(output_grads, kwargs["variables"])
+    else:
+      def grad_fn(*output_grads):
+        return _grad_fn(output_grads)
+
+    return outputs, grad_fn
+
+  return fn_with_recompute(*args)
+
+
+def _underlying_variable_ref(t):
+  """Find the underlying variable ref.
+
+  Traverses through Identity, ReadVariableOp, and Enter ops.
+  Stops when op type has Variable or VarHandle in name.
+
+  Args:
+    t: a Tensor
+
+  Returns:
+    a Tensor that is a variable ref, or None on error.
+  """
+  while t.op.type in ["Identity", "ReadVariableOp", "Enter"]:
+    t = t.op.inputs[0]
+
+  op_type = t.op.type
+  if "Variable" in op_type or "VarHandle" in op_type:
+    return t
+  else:
+    return None
+
+
+def _force_data_dependency(first_compute, then_compute):
+  """Force all of `then_compute` to depend on all of `first_compute`.
+
+  Uses a dummy data dependency, which is useful when running on TPUs because
+  XLA ignores control dependencies. Only supports float arguments.
+
+  Args:
+    first_compute: `list<Tensor>`. These will be made to run before the
+      `Tensor`s `then_compute`.
+    then_compute: `list<Tensor>`. These will run after all the `Tensor`s in
+      `first_compute`.
+
+  Returns:
+    `list<Tensor>`, same length as `then_compute`.
+
+  Raises:
+    ValueError: if ranks are unknown or types are not floating.
+  """
+
+  def _first_element(x):
+    if x.get_shape().ndims is None:
+      raise ValueError("Rank of Tensor %s must be known" % x)
+    ndims = x.get_shape().ndims
+    begin = framework_ops.convert_to_tensor([0] * ndims, dtype=dtypes.int32)
+    size = framework_ops.convert_to_tensor([1] * ndims, dtype=dtypes.int32)
+    return array_ops.reshape(array_ops.slice(x, begin, size), [])
+
+  first_compute_sum = math_ops.add_n(
+      [_first_element(x) for x in first_compute if x is not None])
+  dtype = first_compute_sum.dtype
+  if not dtype.is_floating:
+    raise ValueError("_force_data_dependency only supports floating dtypes.")
+  epsilon = np.finfo(dtype.as_numpy_dtype).tiny
+  zero = array_ops.stop_gradient(epsilon * first_compute_sum)
+
+  return [
+      array_ops.identity(x) + zero if x is not None else None
+      for x in then_compute
+  ]
+
+
+def _tuple_with_data_dep(tensors):
+  return _force_data_dependency(tensors, tensors)

--- a/tensornets/contrib_layers/summaries.py
+++ b/tensornets/contrib_layers/summaries.py
@@ -1,0 +1,164 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Utility functions for summary creation."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import re
+
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import standard_ops
+from tensorflow.python.summary import summary
+
+__all__ = [
+    'summarize_tensor',
+    'summarize_activation',
+    'summarize_tensors',
+    'summarize_collection',
+    'summarize_variables',
+    'summarize_weights',
+    'summarize_biases',
+    'summarize_activations',
+]
+
+# TODO(wicke): add more unit tests for summarization functions.
+
+
+def _add_scalar_summary(tensor, tag=None):
+  """Add a scalar summary operation for the tensor.
+
+  Args:
+    tensor: The tensor to summarize.
+    tag: The tag to use, if None then use tensor's op's name.
+
+  Returns:
+    The created histogram summary.
+
+  Raises:
+    ValueError: If the tag is already in use or the rank is not 0.
+  """
+  tensor.get_shape().assert_has_rank(0)
+  tag = tag or '%s_summary' % tensor.op.name
+  return summary.scalar(tag, tensor)
+
+
+def _add_histogram_summary(tensor, tag=None):
+  """Add a summary operation for the histogram of a tensor.
+
+  Args:
+    tensor: The tensor to summarize.
+    tag: The tag to use, if None then use tensor's op's name.
+
+  Returns:
+    The created histogram summary.
+
+  Raises:
+    ValueError: If the tag is already in use.
+  """
+  tag = tag or '%s_summary' % tensor.op.name
+  return summary.histogram(tag, tensor)
+
+
+def summarize_activation(op):
+  """Summarize an activation.
+
+  This applies the given activation and adds useful summaries specific to the
+  activation.
+
+  Args:
+    op: The tensor to summarize (assumed to be a layer activation).
+  Returns:
+    The summary op created to summarize `op`.
+  """
+  if op.op.type in ('Relu', 'Softplus', 'Relu6'):
+    # Using inputs to avoid floating point equality and/or epsilons.
+    _add_scalar_summary(
+        standard_ops.reduce_mean(
+            standard_ops.to_float(
+                standard_ops.less(op.op.inputs[
+                    0], standard_ops.cast(0.0, op.op.inputs[0].dtype)))),
+        '%s/zeros' % op.op.name)
+  if op.op.type == 'Relu6':
+    _add_scalar_summary(
+        standard_ops.reduce_mean(
+            standard_ops.to_float(
+                standard_ops.greater(op.op.inputs[
+                    0], standard_ops.cast(6.0, op.op.inputs[0].dtype)))),
+        '%s/sixes' % op.op.name)
+  return _add_histogram_summary(op, '%s/activation' % op.op.name)
+
+
+def summarize_tensor(tensor, tag=None):
+  """Summarize a tensor using a suitable summary type.
+
+  This function adds a summary op for `tensor`. The type of summary depends on
+  the shape of `tensor`. For scalars, a `scalar_summary` is created, for all
+  other tensors, `histogram_summary` is used.
+
+  Args:
+    tensor: The tensor to summarize
+    tag: The tag to use, if None then use tensor's op's name.
+
+  Returns:
+    The summary op created or None for string tensors.
+  """
+  # Skips string tensors and boolean tensors (not handled by the summaries).
+  if (tensor.dtype.is_compatible_with(dtypes.string) or
+      tensor.dtype.base_dtype == dtypes.bool):
+    return None
+
+  if tensor.get_shape().ndims == 0:
+    # For scalars, use a scalar summary.
+    return _add_scalar_summary(tensor, tag)
+  else:
+    # We may land in here if the rank is still unknown. The histogram won't
+    # hurt if this ends up being a scalar.
+    return _add_histogram_summary(tensor, tag)
+
+
+def summarize_tensors(tensors, summarizer=summarize_tensor):
+  """Summarize a set of tensors."""
+  return [summarizer(tensor) for tensor in tensors]
+
+
+def summarize_collection(collection,
+                         name_filter=None,
+                         summarizer=summarize_tensor):
+  """Summarize a graph collection of tensors, possibly filtered by name."""
+  tensors = []
+  for op in ops.get_collection(collection):
+    if name_filter is None or re.match(name_filter, op.op.name):
+      tensors.append(op)
+  return summarize_tensors(tensors, summarizer)
+
+
+# Utility functions for commonly used collections
+summarize_variables = functools.partial(summarize_collection,
+                                        ops.GraphKeys.GLOBAL_VARIABLES)
+
+summarize_weights = functools.partial(summarize_collection,
+                                      ops.GraphKeys.WEIGHTS)
+
+summarize_biases = functools.partial(summarize_collection, ops.GraphKeys.BIASES)
+
+
+def summarize_activations(name_filter=None, summarizer=summarize_activation):
+  """Summarize activations, using `summarize_activation` to summarize."""
+  return summarize_collection(ops.GraphKeys.ACTIVATIONS, name_filter,
+                              summarizer)

--- a/tensornets/contrib_layers/utils.py
+++ b/tensornets/contrib_layers/utils.py
@@ -1,0 +1,369 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Common util functions used by layers.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import namedtuple
+from collections import OrderedDict
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework import tensor_util
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import variables
+
+__all__ = ['collect_named_outputs',
+           'constant_value',
+           'static_cond',
+           'smart_cond',
+           'get_variable_collections',
+           'two_element_tuple',
+           'n_positive_integers',
+           'channel_dimension',
+           'last_dimension']
+
+NamedOutputs = namedtuple('NamedOutputs', ['name', 'outputs'])
+
+
+def collect_named_outputs(collections, alias, outputs):
+  """Add `Tensor` outputs tagged with alias to collections.
+
+  It is useful to collect end-points or tags for summaries. Example of usage:
+
+  logits = collect_named_outputs('end_points', 'inception_v3/logits', logits)
+  assert 'inception_v3/logits' in logits.aliases
+
+  Args:
+    collections: A collection or list of collections. If None skip collection.
+    alias: String to append to the list of aliases of outputs, for example,
+           'inception_v3/conv1'.
+    outputs: Tensor, an output tensor to collect
+
+  Returns:
+    The outputs Tensor to allow inline call.
+  """
+  if collections:
+    append_tensor_alias(outputs, alias)
+    ops.add_to_collections(collections, outputs)
+  return outputs
+
+
+def append_tensor_alias(tensor, alias):
+  """Append an alias to the list of aliases of the tensor.
+
+  Args:
+    tensor: A `Tensor`.
+    alias: String, to add to the list of aliases of the tensor.
+
+  Returns:
+    The tensor with a new alias appended to its list of aliases.
+  """
+  # Remove ending '/' if present.
+  if alias[-1] == '/':
+    alias = alias[:-1]
+  if hasattr(tensor, 'aliases'):
+    tensor.aliases.append(alias)
+  else:
+    tensor.aliases = [alias]
+  return tensor
+
+
+def gather_tensors_aliases(tensors):
+  """Given a list of tensors, gather their aliases.
+
+  Args:
+    tensors: A list of `Tensors`.
+
+  Returns:
+    A list of strings with the aliases of all tensors.
+  """
+  aliases = []
+  for tensor in tensors:
+    aliases += get_tensor_aliases(tensor)
+  return aliases
+
+
+def get_tensor_aliases(tensor):
+  """Get a list with the aliases of the input tensor.
+
+  If the tensor does not have any alias, it would default to its its op.name or
+  its name.
+
+  Args:
+    tensor: A `Tensor`.
+
+  Returns:
+    A list of strings with the aliases of the tensor.
+  """
+  if hasattr(tensor, 'aliases'):
+    aliases = tensor.aliases
+  else:
+    if tensor.name[-2:] == ':0':
+      # Use op.name for tensor ending in :0
+      aliases = [tensor.op.name]
+    else:
+      aliases = [tensor.name]
+  return aliases
+
+
+def convert_collection_to_dict(collection, clear_collection=False):
+  """Returns an OrderedDict of Tensors with their aliases as keys.
+
+  Args:
+    collection: A collection.
+    clear_collection: When True, it clears the collection after converting to
+      OrderedDict.
+
+  Returns:
+    An OrderedDict of {alias: tensor}
+  """
+  output = OrderedDict((alias, tensor)
+                       for tensor in ops.get_collection(collection)
+                       for alias in get_tensor_aliases(tensor))
+  if clear_collection:
+    ops.get_default_graph().clear_collection(collection)
+  return output
+
+
+def constant_value(value_or_tensor_or_var, dtype=None):
+  """Returns value if value_or_tensor_or_var has a constant value.
+
+  Args:
+    value_or_tensor_or_var: A value, a `Tensor` or a `Variable`.
+    dtype: Optional `tf.dtype`, if set it would check it has the right
+      dtype.
+
+  Returns:
+    The constant value or None if it not constant.
+
+  Raises:
+    ValueError: if value_or_tensor_or_var is None or the tensor_variable has the
+    wrong dtype.
+  """
+  if value_or_tensor_or_var is None:
+    raise ValueError('value_or_tensor_or_var cannot be None')
+  value = value_or_tensor_or_var
+  if isinstance(value_or_tensor_or_var, (ops.Tensor, variables.Variable)):
+    if dtype and value_or_tensor_or_var.dtype != dtype:
+      raise ValueError('It has the wrong type %s instead of %s' % (
+          value_or_tensor_or_var.dtype, dtype))
+    if isinstance(value_or_tensor_or_var, variables.Variable):
+      value = None
+    else:
+      value = tensor_util.constant_value(value_or_tensor_or_var)
+  return value
+
+
+def static_cond(pred, fn1, fn2):
+  """Return either fn1() or fn2() based on the boolean value of `pred`.
+
+  Same signature as `control_flow_ops.cond()` but requires pred to be a bool.
+
+  Args:
+    pred: A value determining whether to return the result of `fn1` or `fn2`.
+    fn1: The callable to be performed if pred is true.
+    fn2: The callable to be performed if pred is false.
+
+  Returns:
+    Tensors returned by the call to either `fn1` or `fn2`.
+
+  Raises:
+    TypeError: if `fn1` or `fn2` is not callable.
+  """
+  if not callable(fn1):
+    raise TypeError('fn1 must be callable.')
+  if not callable(fn2):
+    raise TypeError('fn2 must be callable.')
+  if pred:
+    return fn1()
+  else:
+    return fn2()
+
+
+def smart_cond(pred, fn1, fn2, name=None):
+  """Return either fn1() or fn2() based on the boolean predicate/value `pred`.
+
+  If `pred` is bool or has a constant value it would use `static_cond`,
+  otherwise it would use `tf.cond`.
+
+  Args:
+    pred: A scalar determining whether to return the result of `fn1` or `fn2`.
+    fn1: The callable to be performed if pred is true.
+    fn2: The callable to be performed if pred is false.
+    name: Optional name prefix when using tf.cond
+  Returns:
+    Tensors returned by the call to either `fn1` or `fn2`.
+  """
+  pred_value = constant_value(pred)
+  if pred_value is not None:
+    # Use static_cond if pred has a constant value.
+    return static_cond(pred_value, fn1, fn2)
+  else:
+    # Use dynamic cond otherwise.
+    return control_flow_ops.cond(pred, fn1, fn2, name)
+
+
+def get_variable_collections(variables_collections, name):
+  if isinstance(variables_collections, dict):
+    variable_collections = variables_collections.get(name, None)
+  else:
+    variable_collections = variables_collections
+  return variable_collections
+
+
+def _get_dimension(shape, dim, min_rank=1):
+  """Returns the `dim` dimension of `shape`, while checking it has `min_rank`.
+
+  Args:
+    shape: A `TensorShape`.
+    dim: Integer, which dimension to return.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the `dim` dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      first dimension value is not defined.
+  """
+  dims = shape.dims
+  if dims is None:
+    raise ValueError('dims of shape must be known but is None')
+  if len(dims) < min_rank:
+    raise ValueError('rank of shape must be at least %d not: %d' % (min_rank,
+                                                                    len(dims)))
+  value = dims[dim].value
+  if value is None:
+    raise ValueError(
+        'dimension %d of shape must be known but is None: %s' % (dim, shape))
+  return value
+
+
+def channel_dimension(shape, data_format, min_rank=1):
+  """Returns the channel dimension of shape, while checking it has min_rank.
+
+  Args:
+    shape: A `TensorShape`.
+    data_format: `channels_first` or `channels_last`.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the first dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      first dimension value is not defined.
+  """
+  return _get_dimension(shape, 1 if data_format == 'channels_first' else -1,
+                        min_rank=min_rank)
+
+
+def last_dimension(shape, min_rank=1):
+  """Returns the last dimension of shape while checking it has min_rank.
+
+  Args:
+    shape: A `TensorShape`.
+    min_rank: Integer, minimum rank of shape.
+
+  Returns:
+    The value of the last dimension.
+
+  Raises:
+    ValueError: if inputs don't have at least min_rank dimensions, or if the
+      last dimension value is not defined.
+  """
+  return _get_dimension(shape, -1, min_rank=min_rank)
+
+
+def two_element_tuple(int_or_tuple):
+  """Converts `int_or_tuple` to height, width.
+
+  Several of the functions that follow accept arguments as either
+  a tuple of 2 integers or a single integer.  A single integer
+  indicates that the 2 values of the tuple are the same.
+
+  This functions normalizes the input value by always returning a tuple.
+
+  Args:
+    int_or_tuple: A list of 2 ints, a single int or a `TensorShape`.
+
+  Returns:
+    A tuple with 2 values.
+
+  Raises:
+    ValueError: If `int_or_tuple` it not well formed.
+  """
+  if isinstance(int_or_tuple, (list, tuple)):
+    if len(int_or_tuple) != 2:
+      raise ValueError('Must be a list with 2 elements: %s' % int_or_tuple)
+    return int(int_or_tuple[0]), int(int_or_tuple[1])
+  if isinstance(int_or_tuple, int):
+    return int(int_or_tuple), int(int_or_tuple)
+  if isinstance(int_or_tuple, tensor_shape.TensorShape):
+    if len(int_or_tuple) == 2:
+      return int_or_tuple[0], int_or_tuple[1]
+  raise ValueError('Must be an int, a list with 2 elements or a TensorShape of '
+                   'length 2')
+
+
+def n_positive_integers(n, value):
+  """Converts `value` to a sequence of `n` positive integers.
+
+  `value` may be either be a sequence of values convertible to `int`, or a
+  single value convertible to `int`, in which case the resulting integer is
+  duplicated `n` times.  It may also be a TensorShape of rank `n`.
+
+  Args:
+    n: Length of sequence to return.
+    value: Either a single value convertible to a positive `int` or an
+      `n`-element sequence of values convertible to a positive `int`.
+
+  Returns:
+    A tuple of `n` positive integers.
+
+  Raises:
+    TypeError: If `n` is not convertible to an integer.
+    ValueError: If `n` or `value` are invalid.
+  """
+
+  n_orig = n
+  n = int(n)
+  if n < 1 or n != n_orig:
+    raise ValueError('n must be a positive integer')
+
+  try:
+    value = int(value)
+  except (TypeError, ValueError):
+    sequence_len = len(value)
+    if sequence_len != n:
+      raise ValueError(
+          'Expected sequence of %d positive integers, but received %r' %
+          (n, value))
+    try:
+      values = tuple(int(x) for x in value)
+    except:
+      raise ValueError(
+          'Expected sequence of %d positive integers, but received %r' %
+          (n, value))
+    for x in values:
+      if x < 1:
+        raise ValueError('expected positive integer, but received %d' % x)
+    return values
+
+  if value < 1:
+    raise ValueError('expected positive integer, but received %d' % value)
+  return (value,) * n

--- a/tensornets/densenets.py
+++ b/tensornets/densenets.py
@@ -96,7 +96,8 @@ def dense(x, blocks, scope=None):
 def transition(x, reduction=0.5, scope=None):
     x = batch_norm(x)
     x = relu(x)
-    x = conv2d(x, x.shape[-1].value * reduction, 1, stride=1)
+    infilters = int(x.shape[-1]) if tf_later_than('2') else x.shape[-1].value
+    x = conv2d(x, int(infilters * reduction), 1, stride=1)
     x = avg_pool2d(x, 2, stride=2, scope='pool')
     return x
 

--- a/tensornets/inceptions.py
+++ b/tensornets/inceptions.py
@@ -101,7 +101,7 @@ def inception1(x, is_training=False, classes=1000,
 @set_args(__args__)
 def inception2(x, is_training=False, classes=1000,
                stem=False, scope=None, reuse=None):
-    x = sconv2d(x, 64, 7, stride=2, depth_multiplier=8., scope='block1')
+    x = sconv2d(x, 64, 7, stride=2, depth_multiplier=8, scope='block1')
     x = max_pool2d(x, 3, stride=2, scope='pool1')
 
     x = conv(x, 64, 1, scope='block2/1')

--- a/tensornets/layers.py
+++ b/tensornets/layers.py
@@ -3,18 +3,6 @@ from __future__ import absolute_import
 import numpy as np
 import tensorflow as tf
 
-from tensorflow.contrib.layers import avg_pool2d
-from tensorflow.contrib.layers import batch_norm
-from tensorflow.contrib.layers import bias_add
-from tensorflow.contrib.layers import conv2d
-from tensorflow.contrib.layers import dropout
-from tensorflow.contrib.layers import flatten
-from tensorflow.contrib.layers import fully_connected as fc
-from tensorflow.contrib.layers import l2_regularizer as l2
-from tensorflow.contrib.layers import max_pool2d
-from tensorflow.contrib.layers import separable_conv2d as sconv2d
-from tensorflow.contrib.layers import variance_scaling_initializer
-
 from .ops import conv2d_primitive
 from .ops import leaky_relu
 from .ops import relu
@@ -23,7 +11,37 @@ from .ops import reshape
 from .ops import swish
 from .utils import arg_scope
 from .utils import remove_commons
-from .utils import variable_scope
+from .version_utils import tf_later_than
+
+
+if tf_later_than('1.14'):
+    tf = tf.compat.v1
+
+
+if tf_later_than('2'):
+    from .contrib_layers import avg_pool2d
+    from .contrib_layers import batch_norm
+    from .contrib_layers import bias_add
+    from .contrib_layers import conv2d
+    from .contrib_layers import dropout
+    from .contrib_layers import flatten
+    from .contrib_layers import fully_connected as fc
+    from .contrib_layers import l2_regularizer as l2
+    from .contrib_layers import max_pool2d
+    from .contrib_layers import separable_conv2d as sconv2d
+    from .contrib_layers import variance_scaling_initializer
+else:
+    from tensorflow.contrib.layers import avg_pool2d
+    from tensorflow.contrib.layers import batch_norm
+    from tensorflow.contrib.layers import bias_add
+    from tensorflow.contrib.layers import conv2d
+    from tensorflow.contrib.layers import dropout
+    from tensorflow.contrib.layers import flatten
+    from tensorflow.contrib.layers import fully_connected as fc
+    from tensorflow.contrib.layers import l2_regularizer as l2
+    from tensorflow.contrib.layers import max_pool2d
+    from tensorflow.contrib.layers import separable_conv2d as sconv2d
+    from tensorflow.contrib.layers import variance_scaling_initializer
 
 
 conv1d = conv2d
@@ -31,47 +49,48 @@ conv1d = conv2d
 
 def convbn(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return batch_norm(conv2d(*args, **kwargs))
 
 
 def convrelu(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu(conv2d(*args, **kwargs))
 
 
 def convrelu0(*args, **kwargs):
     scope = kwargs.pop('scope', None)
     kwargs['biases_initializer'] = tf.zeros_initializer()
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu(conv2d(*args, **kwargs))
 
 
 def convbnrelu(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu(batch_norm(conv2d(*args, **kwargs)))
 
 
 def convbnrelu6(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu6(batch_norm(conv2d(*args, **kwargs)))
 
 
 def convbnswish(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return swish(batch_norm(conv2d(*args, **kwargs)))
 
 
 def gconvbn(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         x = sconv2d(*args, **kwargs)
         c = args[-1]
-        f = x.shape[-1].value // c
+        infilters = int(x.shape[-1]) if tf_later_than('2') else x.shape[-1].value
+        f = infilters // c
         g = f // c
         kernel = np.zeros((1, 1, f * c, f), np.float32)
         for i in range(f):
@@ -85,32 +104,32 @@ def gconvbn(*args, **kwargs):
 
 def sconvbn(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return batch_norm(sconv2d(*args, **kwargs))
 
 
 def sconvbnrelu(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu(batch_norm(sconv2d(*args, **kwargs)))
 
 
 def sconvbnrelu6(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return relu6(batch_norm(sconv2d(*args, **kwargs)))
 
 
 def sconvbnswish(*args, **kwargs):
     scope = kwargs.pop('scope', None)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         return swish(batch_norm(sconv2d(*args, **kwargs)))
 
 
 def darkconv(*args, **kwargs):
     scope = kwargs.pop('scope', None)
     onlyconv = kwargs.pop('onlyconv', False)
-    with variable_scope(scope):
+    with tf.variable_scope(scope):
         conv_kwargs = {
             'padding': 'SAME',
             'activation_fn': None,

--- a/tensornets/middles.py
+++ b/tensornets/middles.py
@@ -1,8 +1,8 @@
 """Collection of representative endpoints for each model."""
 from __future__ import absolute_import
 
-from .utils import tf_equal_to
-from .utils import tf_later_than
+from .version_utils import tf_equal_to
+from .version_utils import tf_later_than
 
 
 def names_inceptions(k, first_block, omit_first=False,
@@ -69,7 +69,9 @@ def tuple_mobilenetv2():
     def baseidx(b):
         return [b, b + 3, b + 5]
     indices = baseidx(2)
-    if tf_later_than('1.3.0'):
+    if tf_later_than('1.15'):
+        bn_name = 'FusedBatchNormV3:0'
+    elif tf_later_than('1.3.0'):
         bn_name = 'FusedBatchNorm:0'
     else:
         bn_name = 'batchnorm/add_1:0'

--- a/tensornets/mobilenets.py
+++ b/tensornets/mobilenets.py
@@ -66,10 +66,11 @@ def block(x, filters, stride=1, scope=None):
 @var_scope('blockv2')
 def block2(x, filters, stride=1, scope=None):
     shortcut = x
-    x = conv(x, 6 * x.shape[-1].value, 1, scope='conv')
+    infilters = int(x.shape[-1]) if tf_later_than('2') else x.shape[-1].value
+    x = conv(x, 6 * infilters, 1, scope='conv')
     x = sconv(x, None, 3, 1, stride=stride, scope='sconv')
     x = convbn(x, filters, 1, stride=1, scope='pconv')
-    if stride == 1 and shortcut.shape[-1].value == filters:
+    if stride == 1 and infilters == filters:
         return add(shortcut, x, name='out')
     else:
         return x

--- a/tensornets/nasnets.py
+++ b/tensornets/nasnets.py
@@ -194,6 +194,7 @@ def normalA(x, p, filters, scope=None):
 @var_scope('reductionA')
 def reductionA(x, p, filters, scope=None):
     """Reduction cell for NASNet-A (Fig. 4 in the paper)"""
+    filters = int(filters)
     p = adjust(p, x, filters)
 
     h = relu(x)
@@ -215,13 +216,15 @@ def reductionA(x, p, filters, scope=None):
 @var_scope('pool')
 def pool(x, filters, stride, scope=None):
     y = max_pool2d(x, 3, stride=stride)
-    if int(x.shape[-1]) != filters:
+    infilters = int(x.shape[-1]) if tf_later_than('2') else x.shape[-1].value
+    if infilters != filters:
         y = conv(y, filters, 1, scope='1x1')
     return y
 
 
 @var_scope('normalP')
 def normalP(x, p, filters, stride=1, scope=None):
+    filters = int(filters)
     p = adjust(p, x, filters)
 
     h = relu(x)

--- a/tensornets/ops.py
+++ b/tensornets/ops.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import
 import tensorflow as tf
 
 from .utils import ops_to_outputs
-from .utils import tf_later_than
+from .version_utils import tf_later_than
+
+
+if tf_later_than('1.14'):
+    tf = tf.compat.v1
 
 
 try:
@@ -79,7 +83,7 @@ def upsample(x, stride, name=None):
     b = tf.shape(x)[0]
     h = tf.shape(x)[1] * stride[0]
     w = tf.shape(x)[2] * stride[1]
-    c = x.shape[-1].value
+    c = int(x.shape[-1]) if tf_later_than('2') else x.shape[-1].value
     x = tf.expand_dims(x, 2)
     x = tf.expand_dims(x, 4)
     x = tf.tile(x, (1, 1, stride[0], 1, stride[1], 1))

--- a/tensornets/references/yolo_utils.py
+++ b/tensornets/references/yolo_utils.py
@@ -5,6 +5,8 @@ import os
 import numpy as np
 import tensorflow as tf
 
+from ..version_utils import tf_later_than
+
 try:
     from .darkflow_utils.get_boxes import yolov3_box
     from .darkflow_utils.get_boxes import yolov2_box
@@ -16,6 +18,10 @@ try:
     xrange          # Python 2
 except NameError:
     xrange = range  # Python 3
+
+
+if tf_later_than('1.14'):
+    tf = tf.compat.v1
 
 
 with open(os.path.join(os.path.dirname(__file__), 'coco.names'), 'r') as f:
@@ -121,8 +127,8 @@ def v2_loss(outs, anchorcoords, classes):
     sconf = 5.
     snoob = 1.
     scoor = 1.
-    H = outs.shape[1].value
-    W = outs.shape[2].value
+    H = int(outs.shape[1]) if tf_later_than('2') else outs.shape[1].value
+    W = int(outs.shape[2]) if tf_later_than('2') else outs.shape[2].value
     cells = H * W
     sizes = np.array([[[[W, H]]]], dtype=np.float32)
     anchors = len(anchorcoords) // 2

--- a/tensornets/version_utils.py
+++ b/tensornets/version_utils.py
@@ -1,0 +1,11 @@
+import tensorflow as tf
+
+from distutils.version import LooseVersion
+
+
+def tf_later_than(v):
+    return LooseVersion(tf.__version__) > LooseVersion(v)
+
+
+def tf_equal_to(v):
+   return tf.__version__ == v

--- a/tests/basics_test.py
+++ b/tests/basics_test.py
@@ -17,6 +17,10 @@ pytestmark = pytest.mark.skipif(
     reason='Runs only when the relevant files have been modified.')
 
 
+if LooseVersion(tf.__version__) > LooseVersion('1.14'):
+    tf = tf.compat.v1
+
+
 @pytest.mark.parametrize('net,shape,weights,outputs,middles', [
     random.choice([
         (nets.ResNet50, (224, 224, 3), 320, 161, 16),
@@ -32,7 +36,7 @@ pytestmark = pytest.mark.skipif(
     random.choice([
         (nets.ResNeXt50, (224, 224, 3), 267, 193, 16),
         (nets.ResNeXt101, (224, 224, 3), 522, 380, 33),
-        (nets.ResNeXt101c64, (224, 224, 3), 522, 380, 33),
+        # (nets.ResNeXt101c64, (224, 224, 3), 522, 380, 33),  # too heavy on Travis
     ]),
     (nets.WideResNet50, (224, 224, 3), 267, 177, 16),
     (nets.Inception1, (224, 224, 3), 116, 143, 11),


### PR DESCRIPTION
This PR adds TF 2 supports. One of the biggest differences between TF 1 and 2 is the depreciation of `tf.contrib` (see [the notice](https://github.com/tensorflow/community/blob/master/rfcs/20180907-contrib-sunset.md)). For now, this PR just copies the `tf.contrib` codes of TF 1.15 and then makes TensorNets work on TF 2. This is one of the temporal solutions. As soon as possible, I will revise the cores of TensorNets as TF 2.0-native.