### PR TITLE
Fix voc's load_train if data_dir is not a list

### DIFF
--- a/tensornets/datasets/voc.py
+++ b/tensornets/datasets/voc.py
@@ -217,6 +217,7 @@ def load_train(data_dir, data_name,
         files = get_files(data_dir, data_name, total_num)
         annotations = get_annotations(data_dir, files)
         dirs = np.zeros(len(files), dtype=np.int)
+        data_dir = [data_dir]  # put in list for consistent further processing
 
     total_num = len(files)
     for f in files:


### PR DESCRIPTION
While trying to train a YOLOv2 model on a single VOC data set (based on `./example/train_yolov2.py`) I run into an error if I provide parameter `data_dir` as a string to the function `voc.load_train`. 

From the first few lines of `voc.load_train` I deduce that it is not mandatory to provide the directory as a list, but that a single directory as a string is also acceptable. However, further down in the function the statement `d = data_dir[dirs[idx[b + i]]]` on line 255 does implicitly assume that `data_dir` is a list. In case it is a string it will simply select the first character of the string (usually `/`), which results in an exception. See the following screenshot.
<img width="1374" alt="voc load_train exception" src="https://user-images.githubusercontent.com/62841433/78405430-c6773480-7600-11ea-8e31-86259b93134f.png">

I have solved this by putting data_dir in a list anyway if it was provided as a single string to the function. I did this at the beginning of the function. This avoids a second if-condition on line 255. There are probably other ways to solve this as well, but this seemed the simplest to me. In case in the future other code relies on `data_dir` being a list as well, it will be handled consistently. 