### PR TITLE
Use items instead of iteritems for dicts

### DIFF
--- a/tensornets/datasets/coco.py
+++ b/tensornets/datasets/coco.py
@@ -182,7 +182,7 @@ def evaluate(results, data_dir, data_name, ovthresh=0.5, verbose=True):
         ids = np.array(ids)
         scores = np.array(scores)
         boxes = np.array(boxes)
-        _annotations = dict((k, v[c]) for (k, v) in annotations.iteritems())
+        _annotations = dict((k, v[c]) for (k, v) in annotations.items())
         ap, _, _ = evaluate_class(ids, scores, boxes, _annotations,
                                   fileids, ovthresh)
         aps += [ap]

--- a/tensornets/datasets/voc.py
+++ b/tensornets/datasets/voc.py
@@ -177,7 +177,7 @@ def evaluate(results, data_dir, data_name, ovthresh=0.5, verbose=True):
         ids = np.array(ids)
         scores = np.array(scores)
         boxes = np.array(boxes)
-        _annotations = dict((k, v[c]) for (k, v) in annotations.iteritems())
+        _annotations = dict((k, v[c]) for (k, v) in annotations.items())
         ap, _, _ = evaluate_class(ids, scores, boxes, _annotations,
                                   files, ovthresh)
         aps += [ap]


### PR DESCRIPTION
While trying to train a YOLOv2 model (based on `./example/train_yolov2.py`) I run into an error:
> Traceback (most recent call last):
>   File "/Users/Nico/Developer/VSCode/train_yolov2.py", line 69, in <module>
>     print(voc.evaluate(results, data_dir % 2007, 'val'))
>   File "/Users/Nico/anaconda3/envs/yolo/lib/python3.7/site-packages/tensornets/datasets/voc.py", line 180, in evaluate
>     _annotations = dict((k, v[c]) for (k, v) in annotations.iteritems())
> AttributeError: 'dict' object has no attribute 'iteritems'

Dictionaries in Python 3 no longer have a method `iteritems()`, but have `items()` instead. The method `items()` exists in Python 2 as well. So, I changed `voc.evaluate` (as well as `coco.evaluate`) to use `items()`. 

`items()` is potentially not efficient on Python 2. As Python 2 is EOL, perhaps this is acceptable. If this is a concern, I could modify the change. AFAIK this is only easily possible with an additional package. See [here](https://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items) for an example.